### PR TITLE
[conluz-135] Changed calculation of monthly and yearly datadis consumptions to run as independent jobs that aggregate data from hourly data

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisMonthlyAggregationRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisMonthlyAggregationRepository.java
@@ -1,0 +1,23 @@
+package org.lucoenergia.conluz.domain.consumption.datadis.aggregate;
+
+import jakarta.validation.constraints.NotNull;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+
+import java.time.Month;
+
+/**
+ * Repository for aggregating hourly Datadis consumption data into monthly totals
+ * using InfluxDB aggregation queries.
+ */
+public interface DatadisMonthlyAggregationRepository {
+
+    /**
+     * Aggregates hourly consumption data into a monthly total for a specific supply,
+     * month, and year using InfluxQL SUM queries.
+     *
+     * @param supply the supply to aggregate
+     * @param month the month to aggregate
+     * @param year the year to aggregate
+     */
+    void aggregateMonthlyConsumption(@NotNull Supply supply, @NotNull Month month, @NotNull int year);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisMonthlyAggregationService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisMonthlyAggregationService.java
@@ -1,0 +1,39 @@
+package org.lucoenergia.conluz.domain.consumption.datadis.aggregate;
+
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+
+import java.time.Month;
+
+/**
+ * Service for aggregating Datadis hourly consumption data into monthly totals.
+ * Uses InfluxQL queries to aggregate data directly in the database.
+ */
+public interface DatadisMonthlyAggregationService {
+
+    /**
+     * Aggregates hourly consumption data into monthly totals for all supplies
+     * for a specific year.
+     *
+     * @param year the year to aggregate
+     */
+    void aggregateMonthlyConsumptions(int year);
+
+    /**
+     * Aggregates hourly consumption data into monthly totals for a specific supply,
+     * month, and year.
+     *
+     * @param supplyCode the supply code to aggregate
+     * @param month the month to aggregate
+     * @param year the year to aggregate
+     */
+    void aggregateMonthlyConsumptions(SupplyCode supplyCode, Month month, int year);
+
+    /**
+     * Aggregates hourly consumption data into monthly totals for all supplies
+     * for a specific month and year.
+     *
+     * @param month the month to aggregate
+     * @param year the year to aggregate
+     */
+    void aggregateMonthlyConsumptions(Month month, int year);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisYearlyAggregationRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisYearlyAggregationRepository.java
@@ -1,0 +1,20 @@
+package org.lucoenergia.conluz.domain.consumption.datadis.aggregate;
+
+import jakarta.validation.constraints.NotNull;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+
+/**
+ * Repository for aggregating monthly Datadis consumption data into yearly totals
+ * using InfluxDB aggregation queries.
+ */
+public interface DatadisYearlyAggregationRepository {
+
+    /**
+     * Aggregates monthly consumption data into a yearly total for a specific supply
+     * and year using InfluxQL SUM queries.
+     *
+     * @param supply the supply to aggregate
+     * @param year the year to aggregate
+     */
+    void aggregateYearlyConsumption(@NotNull Supply supply, @NotNull int year);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisYearlyAggregationService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisYearlyAggregationService.java
@@ -1,0 +1,27 @@
+package org.lucoenergia.conluz.domain.consumption.datadis.aggregate;
+
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+
+/**
+ * Service for aggregating Datadis monthly consumption data into yearly totals.
+ * Uses InfluxQL queries to aggregate data directly in the database.
+ */
+public interface DatadisYearlyAggregationService {
+
+    /**
+     * Aggregates monthly consumption data into yearly totals for all supplies
+     * for a specific year.
+     *
+     * @param year the year to aggregate
+     */
+    void aggregateYearlyConsumptions(int year);
+
+    /**
+     * Aggregates monthly consumption data into yearly totals for a specific supply
+     * and year.
+     *
+     * @param supplyCode the supply code to aggregate
+     * @param year the year to aggregate
+     */
+    void aggregateYearlyConsumptions(SupplyCode supplyCode, int year);
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionMonthlyPoint.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionMonthlyPoint.java
@@ -19,6 +19,8 @@ public class DatadisConsumptionMonthlyPoint {
     private String obtainMethod;
     @Column(name = "surplus_energy_kwh")
     private Double surplusEnergyKWh;
+    @Column(name = "generation_energy_kwh")
+    private Double generationEnergyKWh;
     @Column(name = "self_consumption_energy_kwh")
     private Double selfConsumptionEnergyKWh;
 
@@ -40,6 +42,10 @@ public class DatadisConsumptionMonthlyPoint {
 
     public Double getSurplusEnergyKWh() {
         return surplusEnergyKWh;
+    }
+
+    public Double getGenerationEnergyKWh() {
+        return generationEnergyKWh;
     }
 
     public Double getSelfConsumptionEnergyKWh() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionPoint.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionPoint.java
@@ -19,6 +19,8 @@ public class DatadisConsumptionPoint {
     private String obtainMethod;
     @Column(name = "surplus_energy_kwh")
     private Double surplusEnergyKWh;
+    @Column(name = "generation_energy_kwh")
+    private Double generationEnergyKWh;
     @Column(name = "self_consumption_energy_kwh")
     private Double selfConsumptionEnergyKWh;
 
@@ -40,6 +42,10 @@ public class DatadisConsumptionPoint {
 
     public Double getSurplusEnergyKWh() {
         return surplusEnergyKWh;
+    }
+
+    public Double getGenerationEnergyKWh() {
+        return generationEnergyKWh;
     }
 
     public Double getSelfConsumptionEnergyKWh() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionYearlyPoint.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionYearlyPoint.java
@@ -19,6 +19,8 @@ public class DatadisConsumptionYearlyPoint {
     private String obtainMethod;
     @Column(name = "surplus_energy_kwh")
     private Double surplusEnergyKWh;
+    @Column(name = "generation_energy_kwh")
+    private Double generationEnergyKWh;
     @Column(name = "self_consumption_energy_kwh")
     private Double selfConsumptionEnergyKWh;
 
@@ -40,6 +42,10 @@ public class DatadisConsumptionYearlyPoint {
 
     public Double getSurplusEnergyKWh() {
         return surplusEnergyKWh;
+    }
+
+    public Double getGenerationEnergyKWh() {
+        return generationEnergyKWh;
     }
 
     public Double getSelfConsumptionEnergyKWh() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationJob.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationJob.java
@@ -1,0 +1,55 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationService;
+import org.lucoenergia.conluz.infrastructure.shared.job.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+@Component
+public class DatadisMonthlyAggregationJob implements Job {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatadisMonthlyAggregationJob.class);
+
+    private final DatadisMonthlyAggregationService aggregationService;
+
+    public DatadisMonthlyAggregationJob(DatadisMonthlyAggregationService aggregationService) {
+        this.aggregationService = aggregationService;
+    }
+
+    /**
+     * Aggregate hourly consumption data into monthly totals at 5:00 AM every day.
+     * This job aggregates data for the current month for all supplies.
+     *
+     * Cron expression breakdown:
+     * 0 seconds (at the start of the minute)
+     * 0 minutes (at the start of the hour)
+     * 5 (at 5 AM)
+     * * (every day)
+     * * (every month)
+     * ? (any day of the week)
+     *
+     * Rationale:
+     * - Runs at 5 AM to avoid conflicts with hourly sync job (4 AM)
+     * - Runs every day to have updated data for the month daily
+     * - By this time, the hourly sync job should have synced all data from previous month
+     */
+    @Override
+    @Scheduled(cron = "0 0 5 * * ?")
+    public void run() {
+        LOGGER.info("Datadis monthly aggregation started...");
+
+        LocalDate today = LocalDate.now();
+        Month month = today.getMonth();
+        int year = today.getYear();
+
+        LOGGER.info("Aggregating data for month: {}, year: {}", month, year);
+        aggregationService.aggregateMonthlyConsumptions(month, year);
+
+        LOGGER.info("...finished Datadis monthly aggregation.");
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationRepositoryInflux.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationRepositoryInflux.java
@@ -1,0 +1,110 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.influxdb.impl.InfluxDBResultMapper;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationRepository;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.DatadisConsumptionPoint;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.config.DatadisConfigEntity;
+import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxDbConnectionManager;
+import org.lucoenergia.conluz.infrastructure.shared.time.DateConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class DatadisMonthlyAggregationRepositoryInflux implements DatadisMonthlyAggregationRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatadisMonthlyAggregationRepositoryInflux.class);
+
+    private final InfluxDbConnectionManager influxDbConnectionManager;
+    private final DateConverter dateConverter;
+
+    public DatadisMonthlyAggregationRepositoryInflux(InfluxDbConnectionManager influxDbConnectionManager,
+                                                     DateConverter dateConverter) {
+        this.influxDbConnectionManager = influxDbConnectionManager;
+        this.dateConverter = dateConverter;
+    }
+
+    @Override
+    public void aggregateMonthlyConsumption(Supply supply, Month month, int year) {
+
+        final String startDate = dateConverter.convertToFirstDayOfTheMonthAsString(month, year);
+        final String endDate = dateConverter.convertToLastDayOfTheMonthAsString(month, year);
+
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+
+            // Query to aggregate hourly data into monthly totals
+            Query query = new Query(String.format(
+                    """
+                    SELECT
+                        SUM("consumption_kwh") AS "consumption_kwh",
+                        SUM("surplus_energy_kwh") AS "surplus_energy_kwh",
+                        SUM("self_consumption_energy_kwh") AS "self_consumption_energy_kwh",
+                        SUM("generation_energy_kwh") AS "generation_energy_kwh",
+                        LAST("obtain_method") AS "obtain_method"
+                    FROM "%s"
+                    WHERE cups = '%s'
+                        AND time >= '%s'
+                        AND time <= '%s'
+                    GROUP BY cups
+                    """,
+                    DatadisConfigEntity.CONSUMPTION_KWH_MEASUREMENT,
+                    supply.getCode(),
+                    startDate,
+                    endDate));
+
+            QueryResult queryResult = connection.query(query);
+
+            if (queryResult.hasError()) {
+                LOGGER.error("Query to aggregate monthly consumption returned error: {}", queryResult.getError());
+                return;
+            }
+
+            InfluxDBResultMapper resultMapper = new InfluxDBResultMapper();
+            List<DatadisConsumptionPoint> aggregatedData = resultMapper.toPOJO(queryResult, DatadisConsumptionPoint.class);
+
+            if (aggregatedData.isEmpty()) {
+                LOGGER.warn("No hourly data found to aggregate for supply: {}, month: {}, year: {}",
+                        supply.getCode(), month, year);
+                return;
+            }
+
+            // Persist the aggregated monthly data
+            DatadisConsumptionPoint aggregated = aggregatedData.get(0);
+
+            // Calculate timestamp for first day of month at midnight (local timezone)
+            LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
+            String formattedDate = firstDayOfMonth.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+            long timestamp = dateConverter.convertStringDateToMilliseconds(formattedDate + "T00:00");
+
+            BatchPoints batchPoints = influxDbConnectionManager.createBatchPoints();
+
+            Point point = Point.measurement(DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT)
+                    .time(timestamp, TimeUnit.MILLISECONDS)
+                    .tag("cups", supply.getCode())
+                    .addField("consumption_kwh", aggregated.getConsumptionKWh() != null ? aggregated.getConsumptionKWh() : 0.0)
+                    .addField("surplus_energy_kwh", aggregated.getSurplusEnergyKWh() != null ? aggregated.getSurplusEnergyKWh() : 0.0)
+                    .addField("generation_energy_kwh", aggregated.getGenerationEnergyKWh() != null ? aggregated.getGenerationEnergyKWh() : 0.0)
+                    .addField("self_consumption_energy_kwh", aggregated.getSelfConsumptionEnergyKWh() != null ? aggregated.getSelfConsumptionEnergyKWh() : 0.0)
+                    .addField("obtain_method", aggregated.getObtainMethod() != null ? aggregated.getObtainMethod() : "")
+                    .build();
+
+            batchPoints.point(point);
+            connection.write(batchPoints);
+
+            LOGGER.debug("Persisted monthly aggregation for supply: {}, month: {}, year: {}",
+                    supply.getCode(), month, year);
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationServiceImpl.java
@@ -1,0 +1,89 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationRepository;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationService;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Month;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DatadisMonthlyAggregationServiceImpl implements DatadisMonthlyAggregationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatadisMonthlyAggregationServiceImpl.class);
+
+    private final GetSupplyRepository getSupplyRepository;
+    private final DatadisMonthlyAggregationRepository aggregationRepository;
+
+    public DatadisMonthlyAggregationServiceImpl(GetSupplyRepository getSupplyRepository,
+                                                DatadisMonthlyAggregationRepository aggregationRepository) {
+        this.getSupplyRepository = getSupplyRepository;
+        this.aggregationRepository = aggregationRepository;
+    }
+
+    @Override
+    public void aggregateMonthlyConsumptions(int year) {
+        List<Supply> allSupplies = getSupplyRepository.findAll();
+
+        for (Supply supply : allSupplies) {
+            if (supply.getDistributorCode() == null || supply.getDistributorCode().isBlank()) {
+                LOGGER.warn("Skipping supply with ID: {} because it does not have distributor code", supply.getId());
+                continue;
+            }
+
+            for (Month month : Month.values()) {
+                aggregateForSupplyMonthYear(supply, month, year);
+            }
+        }
+    }
+
+    @Override
+    public void aggregateMonthlyConsumptions(SupplyCode supplyCode, Month month, int year) {
+        Optional<Supply> supplyOptional = getSupplyRepository.findByCode(supplyCode);
+        if (supplyOptional.isEmpty()) {
+            throw new SupplyNotFoundException(supplyCode);
+        }
+
+        Supply supply = supplyOptional.get();
+        if (supply.getDistributorCode() == null || supply.getDistributorCode().isBlank()) {
+            LOGGER.warn("Skipping supply with ID: {} because it does not have distributor code", supply.getId());
+            return;
+        }
+
+        aggregateForSupplyMonthYear(supply, month, year);
+    }
+
+    @Override
+    public void aggregateMonthlyConsumptions(Month month, int year) {
+        List<Supply> allSupplies = getSupplyRepository.findAll();
+
+        for (Supply supply : allSupplies) {
+            if (supply.getDistributorCode() == null || supply.getDistributorCode().isBlank()) {
+                LOGGER.warn("Skipping supply with ID: {} because it does not have distributor code", supply.getId());
+                continue;
+            }
+
+            aggregateForSupplyMonthYear(supply, month, year);
+        }
+    }
+
+    private void aggregateForSupplyMonthYear(Supply supply, Month month, int year) {
+        try {
+            LOGGER.info("Aggregating monthly consumption for supply ID: {}, month: {}, year: {}",
+                    supply.getId(), month, year);
+            aggregationRepository.aggregateMonthlyConsumption(supply, month, year);
+            LOGGER.info("Successfully aggregated monthly consumption for supply ID: {}, month: {}, year: {}",
+                    supply.getId(), month, year);
+        } catch (Exception e) {
+            LOGGER.error("Failed to aggregate monthly consumption for supply ID: {}, month: {}, year: {}",
+                    supply.getId(), month, year, e);
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationJob.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationJob.java
@@ -1,0 +1,53 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationService;
+import org.lucoenergia.conluz.infrastructure.shared.job.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class DatadisYearlyAggregationJob implements Job {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatadisYearlyAggregationJob.class);
+
+    private final DatadisYearlyAggregationService aggregationService;
+
+    public DatadisYearlyAggregationJob(DatadisYearlyAggregationService aggregationService) {
+        this.aggregationService = aggregationService;
+    }
+
+    /**
+     * Aggregate monthly consumption data into yearly totals at 6:00 AM every day.
+     * This job aggregates data for the current year for all supplies.
+     *
+     * Cron expression breakdown:
+     * 0 seconds (at the start of the minute)
+     * 0 minutes (at the start of the hour)
+     * 6 (at 6 AM)
+     * * (every day)
+     * * (every month)
+     * ? (any day of the week)
+     *
+     * Rationale:
+     * - Runs at 6 AM to avoid conflicts with hourly sync (4 AM) and monthly aggregation (5 AM) jobs.
+     * - Runs every day to have update aggregated yearly consumption daily.
+     * - By this time, all monthly aggregations for the previous year should be complete.
+     */
+    @Override
+    @Scheduled(cron = "0 0 6 * * ?")
+    public void run() {
+        LOGGER.info("Datadis yearly aggregation started...");
+
+        LocalDate today = LocalDate.now();
+        int year = today.getYear();
+
+        LOGGER.info("Aggregating data for year: {}", year);
+        aggregationService.aggregateYearlyConsumptions(year);
+
+        LOGGER.info("...finished Datadis yearly aggregation.");
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationRepositoryInflux.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationRepositoryInflux.java
@@ -1,0 +1,107 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.influxdb.impl.InfluxDBResultMapper;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationRepository;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.DatadisConsumptionMonthlyPoint;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.config.DatadisConfigEntity;
+import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxDbConnectionManager;
+import org.lucoenergia.conluz.infrastructure.shared.time.DateConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class DatadisYearlyAggregationRepositoryInflux implements DatadisYearlyAggregationRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatadisYearlyAggregationRepositoryInflux.class);
+
+    private final InfluxDbConnectionManager influxDbConnectionManager;
+    private final DateConverter dateConverter;
+
+    public DatadisYearlyAggregationRepositoryInflux(InfluxDbConnectionManager influxDbConnectionManager,
+                                                    DateConverter dateConverter) {
+        this.influxDbConnectionManager = influxDbConnectionManager;
+        this.dateConverter = dateConverter;
+    }
+
+    @Override
+    public void aggregateYearlyConsumption(Supply supply, int year) {
+
+        String startDate = String.format("%d-01-01T00:00:00Z", year);
+        String endDate = String.format("%d-12-31T23:59:59Z", year);
+
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+
+            // Query to aggregate monthly data into yearly totals
+            Query query = new Query(String.format(
+                    """
+                    SELECT
+                        SUM("consumption_kwh") AS "consumption_kwh",
+                        SUM("surplus_energy_kwh") AS "surplus_energy_kwh",
+                        SUM("self_consumption_energy_kwh") AS "self_consumption_energy_kwh",
+                        SUM("generation_energy_kwh") AS "generation_energy_kwh",
+                        LAST("obtain_method") AS "obtain_method"
+                    FROM "%s"
+                    WHERE cups = '%s'
+                        AND time >= '%s'
+                        AND time <= '%s'
+                    GROUP BY cups
+                    """,
+                    DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT,
+                    supply.getCode(),
+                    startDate,
+                    endDate));
+
+            QueryResult queryResult = connection.query(query);
+
+            if (queryResult.hasError()) {
+                LOGGER.error("Query to aggregate yearly consumption returned error: {}", queryResult.getError());
+                return;
+            }
+
+            InfluxDBResultMapper resultMapper = new InfluxDBResultMapper();
+            List<DatadisConsumptionMonthlyPoint> aggregatedData = resultMapper.toPOJO(queryResult, DatadisConsumptionMonthlyPoint.class);
+
+            if (aggregatedData.isEmpty()) {
+                LOGGER.warn("No monthly data found to aggregate for supply: {}, year: {}", supply.getCode(), year);
+                return;
+            }
+
+            // Persist the aggregated yearly data
+            DatadisConsumptionMonthlyPoint aggregated = aggregatedData.get(0);
+
+            // Calculate timestamp for December 31st of the year at midnight (local timezone)
+            LocalDate lastDayOfYear = LocalDate.of(year, 12, 31);
+            String formattedDate = lastDayOfYear.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+            long timestamp = dateConverter.convertStringDateToMilliseconds(formattedDate + "T00:00");
+
+            BatchPoints batchPoints = influxDbConnectionManager.createBatchPoints();
+
+            Point point = Point.measurement(DatadisConfigEntity.CONSUMPTION_KWH_YEAR_MEASUREMENT)
+                    .time(timestamp, TimeUnit.MILLISECONDS)
+                    .tag("cups", supply.getCode())
+                    .addField("consumption_kwh", aggregated.getConsumptionKWh() != null ? aggregated.getConsumptionKWh() : 0.0)
+                    .addField("surplus_energy_kwh", aggregated.getSurplusEnergyKWh() != null ? aggregated.getSurplusEnergyKWh() : 0.0)
+                    .addField("generation_energy_kwh", aggregated.getGenerationEnergyKWh() != null ? aggregated.getGenerationEnergyKWh() : 0.0)
+                    .addField("self_consumption_energy_kwh", aggregated.getSelfConsumptionEnergyKWh() != null ? aggregated.getSelfConsumptionEnergyKWh() : 0.0)
+                    .addField("obtain_method", aggregated.getObtainMethod() != null ? aggregated.getObtainMethod() : "")
+                    .build();
+
+            batchPoints.point(point);
+            connection.write(batchPoints);
+
+            LOGGER.debug("Persisted yearly aggregation for supply: {}, year: {}", supply.getCode(), year);
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationServiceImpl.java
@@ -1,0 +1,70 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationRepository;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationService;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DatadisYearlyAggregationServiceImpl implements DatadisYearlyAggregationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatadisYearlyAggregationServiceImpl.class);
+
+    private final GetSupplyRepository getSupplyRepository;
+    private final DatadisYearlyAggregationRepository aggregationRepository;
+
+    public DatadisYearlyAggregationServiceImpl(GetSupplyRepository getSupplyRepository,
+                                               DatadisYearlyAggregationRepository aggregationRepository) {
+        this.getSupplyRepository = getSupplyRepository;
+        this.aggregationRepository = aggregationRepository;
+    }
+
+    @Override
+    public void aggregateYearlyConsumptions(int year) {
+        List<Supply> allSupplies = getSupplyRepository.findAll();
+
+        for (Supply supply : allSupplies) {
+            if (supply.getDistributorCode() == null || supply.getDistributorCode().isBlank()) {
+                LOGGER.warn("Skipping supply with ID: {} because it does not have distributor code", supply.getId());
+                continue;
+            }
+
+            aggregateForSupplyYear(supply, year);
+        }
+    }
+
+    @Override
+    public void aggregateYearlyConsumptions(SupplyCode supplyCode, int year) {
+        Optional<Supply> supplyOptional = getSupplyRepository.findByCode(supplyCode);
+        if (supplyOptional.isEmpty()) {
+            throw new SupplyNotFoundException(supplyCode);
+        }
+
+        Supply supply = supplyOptional.get();
+        if (supply.getDistributorCode() == null || supply.getDistributorCode().isBlank()) {
+            LOGGER.warn("Skipping supply with ID: {} because it does not have distributor code", supply.getId());
+            return;
+        }
+
+        aggregateForSupplyYear(supply, year);
+    }
+
+    private void aggregateForSupplyYear(Supply supply, int year) {
+        try {
+            LOGGER.info("Aggregating yearly consumption for supply ID: {}, year: {}", supply.getId(), year);
+            aggregationRepository.aggregateYearlyConsumption(supply, year);
+            LOGGER.info("Successfully aggregated yearly consumption for supply ID: {}, year: {}", supply.getId(), year);
+        } catch (Exception e) {
+            LOGGER.error("Failed to aggregate yearly consumption for supply ID: {}, year: {}",
+                    supply.getId(), year, e);
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/get/GetDatadisConsumptionRepositoryInflux.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/get/GetDatadisConsumptionRepositoryInflux.java
@@ -149,6 +149,7 @@ public class GetDatadisConsumptionRepositoryInflux implements GetDatadisConsumpt
                     consumption.setConsumptionKWh(parseToFloat(consumptionPoint.getConsumptionKWh()));
                     consumption.setSelfConsumptionEnergyKWh(parseToFloat(consumptionPoint.getSelfConsumptionEnergyKWh()));
                     consumption.setSurplusEnergyKWh(parseToFloat(consumptionPoint.getSurplusEnergyKWh()));
+                    consumption.setGenerationEnergyKWh(parseToFloat(consumptionPoint.getGenerationEnergyKWh()));
                     consumption.setObtainMethod(consumptionPoint.getObtainMethod());
                     return consumption;
                 })
@@ -165,6 +166,7 @@ public class GetDatadisConsumptionRepositoryInflux implements GetDatadisConsumpt
                     consumption.setConsumptionKWh(parseToFloat(consumptionPoint.getConsumptionKWh()));
                     consumption.setSelfConsumptionEnergyKWh(parseToFloat(consumptionPoint.getSelfConsumptionEnergyKWh()));
                     consumption.setSurplusEnergyKWh(parseToFloat(consumptionPoint.getSurplusEnergyKWh()));
+                    consumption.setGenerationEnergyKWh(parseToFloat(consumptionPoint.getGenerationEnergyKWh()));
                     consumption.setObtainMethod(consumptionPoint.getObtainMethod());
                     return consumption;
                 })
@@ -181,6 +183,7 @@ public class GetDatadisConsumptionRepositoryInflux implements GetDatadisConsumpt
                     consumption.setConsumptionKWh(parseToFloat(consumptionPoint.getConsumptionKWh()));
                     consumption.setSelfConsumptionEnergyKWh(parseToFloat(consumptionPoint.getSelfConsumptionEnergyKWh()));
                     consumption.setSurplusEnergyKWh(parseToFloat(consumptionPoint.getSurplusEnergyKWh()));
+                    consumption.setGenerationEnergyKWh(parseToFloat(consumptionPoint.getGenerationEnergyKWh()));
                     consumption.setObtainMethod(consumptionPoint.getObtainMethod());
                     return consumption;
                 })

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/DatadisConsumptionSyncServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/DatadisConsumptionSyncServiceImpl.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class DatadisConsumptionSyncServiceImpl implements DatadisConsumptionSyncService {
@@ -28,16 +29,13 @@ public class DatadisConsumptionSyncServiceImpl implements DatadisConsumptionSync
     private final GetDatadisConsumptionRepository getDatadisConsumptionRepository;
     private final GetSupplyRepository getSupplyRepository;
     private final PersistDatadisConsumptionRepository persistDatadisConsumptionRepository;
-    private final DateConverter dateConverter;
 
     public DatadisConsumptionSyncServiceImpl(@Qualifier("getDatadisConsumptionRepositoryRest") GetDatadisConsumptionRepository getDatadisConsumptionRepository,
                                              GetSupplyRepository getSupplyRepository,
-                                             PersistDatadisConsumptionRepository persistDatadisConsumptionRepository,
-                                             DateConverter dateConverter) {
+                                             PersistDatadisConsumptionRepository persistDatadisConsumptionRepository) {
         this.getDatadisConsumptionRepository = getDatadisConsumptionRepository;
         this.getSupplyRepository = getSupplyRepository;
         this.persistDatadisConsumptionRepository = persistDatadisConsumptionRepository;
-        this.dateConverter = dateConverter;
     }
 
     @Override
@@ -66,7 +64,6 @@ public class DatadisConsumptionSyncServiceImpl implements DatadisConsumptionSync
         LOGGER.info("Processing supply with ID: {}", supply.getId());
 
         LocalDate validDateFrom = startDate;
-        List<DatadisConsumption> aggregatedMonthlyConsumptions = new ArrayList<>();
 
         while (validDateFrom.isBefore(endDate) || validDateFrom.isEqual(endDate)) {
 
@@ -81,9 +78,6 @@ public class DatadisConsumptionSyncServiceImpl implements DatadisConsumptionSync
                 if (!consumptions.isEmpty()) {
                     persistDatadisConsumptionRepository.persistHourlyConsumptions(consumptions);
                     LOGGER.info("Hourly consumptions persisted");
-                    // Calculate aggregated monthly consumption
-                    DatadisConsumption aggregatedMonthlyConsumption = calculateMonthlyAggregatedConsumption(consumptions);
-                    aggregatedMonthlyConsumptions.add(aggregatedMonthlyConsumption);
                 } else {
                     LOGGER.warn("Hourly consumptions are empty");
                 }
@@ -94,106 +88,6 @@ public class DatadisConsumptionSyncServiceImpl implements DatadisConsumptionSync
 
             validDateFrom = validDateFrom.plusMonths(1);
         }
-
-        // Persist monthly consumption
-        if (!aggregatedMonthlyConsumptions.isEmpty()) {
-            persistDatadisConsumptionRepository.persistMonthlyConsumptions(aggregatedMonthlyConsumptions);
-            LOGGER.info("Monthly consumptions persisted");
-
-            // Calculate and persist yearly consumption
-            List<DatadisConsumption> aggregatedYearlyConsumption = calculateYearlyAggregatedConsumption(aggregatedMonthlyConsumptions);
-            if (!aggregatedYearlyConsumption.isEmpty()) {
-                persistDatadisConsumptionRepository.persistYearlyConsumptions(aggregatedYearlyConsumption);
-                LOGGER.info("Yearly consumptions persisted");
-            } else {
-                LOGGER.warn("Yearly consumptions are empty");
-            }
-
-        } else {
-            LOGGER.warn("Monthly consumptions are empty");
-        }
     }
 
-    private DatadisConsumption calculateMonthlyAggregatedConsumption(List<DatadisConsumption> consumptions) {
-        DatadisConsumption aggregated = new DatadisConsumption();
-
-        Float totalConsumption = consumptions.stream()
-                .map(DatadisConsumption::getConsumptionKWh)
-                .filter(Objects::nonNull)
-                .reduce(0f, Float::sum);
-
-        Float totalSurplus = consumptions.stream()
-                .map(DatadisConsumption::getSurplusEnergyKWh)
-                .filter(Objects::nonNull)
-                .reduce(0f, Float::sum);
-
-        Float totalGeneration = consumptions.stream()
-                .map(DatadisConsumption::getGenerationEnergyKWh)
-                .filter(Objects::nonNull)
-                .reduce(0f, Float::sum);
-
-        Float totalSelfConsumption = consumptions.stream()
-                .map(DatadisConsumption::getSelfConsumptionEnergyKWh)
-                .filter(Objects::nonNull)
-                .reduce(0f, Float::sum);
-
-        DatadisConsumption firstConsumption = consumptions.get(0);
-        aggregated.setCups(firstConsumption.getCups());
-        aggregated.setDate(firstConsumption.getDate());
-        aggregated.setTime(firstConsumption.getTime());
-        aggregated.setObtainMethod(firstConsumption.getObtainMethod());
-        aggregated.setConsumptionKWh(totalConsumption);
-        aggregated.setSurplusEnergyKWh(totalSurplus);
-        aggregated.setGenerationEnergyKWh(totalGeneration);
-        aggregated.setSelfConsumptionEnergyKWh(totalSelfConsumption);
-
-        return aggregated;
-    }
-
-    private List<DatadisConsumption> calculateYearlyAggregatedConsumption(List<DatadisConsumption> consumptions) {
-        List<DatadisConsumption> yearsConsumptions = new ArrayList<>();
-
-        DatadisConsumption firstConsumption = consumptions.get(0);
-        String cups = firstConsumption.getCups();
-        String obtainMethod = firstConsumption.getObtainMethod();
-
-        Map<Integer, Float> consumptionByYear = new HashMap<>();
-        Map<Integer, Float> surplusByYear = new HashMap<>();
-        Map<Integer, Float> generationByYear = new HashMap<>();
-        Map<Integer, Float> selfConsumptionByYear = new HashMap<>();
-
-        for (DatadisConsumption monthConsumption : consumptions) {
-
-            int year = dateConverter.getYearFromStringDate(monthConsumption.getDate());
-
-            // Consumption
-            consumptionByYear.merge(year, monthConsumption.getConsumptionKWh(), Float::sum);
-
-            // Surplus
-            surplusByYear.merge(year, monthConsumption.getSurplusEnergyKWh(), Float::sum);
-
-            // Generation
-            generationByYear.merge(year, monthConsumption.getGenerationEnergyKWh(), Float::sum);
-
-            // Self consumption
-            selfConsumptionByYear.merge(year, monthConsumption.getSelfConsumptionEnergyKWh(), Float::sum);
-        }
-
-        for (int year : consumptionByYear.keySet()) {
-
-            DatadisConsumption yearConsumption = new DatadisConsumption();
-            yearConsumption.setCups(cups);
-            yearConsumption.setDate(year + "/12/31");
-            yearConsumption.setTime("00:00");
-            yearConsumption.setObtainMethod(obtainMethod);
-            yearConsumption.setConsumptionKWh(consumptionByYear.getOrDefault(year, 0.0f));
-            yearConsumption.setSurplusEnergyKWh(surplusByYear.getOrDefault(year, 0.0f));
-            yearConsumption.setGenerationEnergyKWh(generationByYear.getOrDefault(year, 0.0f));
-            yearConsumption.setSelfConsumptionEnergyKWh(selfConsumptionByYear.getOrDefault(year, 0.0f));
-
-            yearsConsumptions.add(yearConsumption);
-        }
-
-        return yearsConsumptions;
-    }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncMonthlyDatadisConsumptionsBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncMonthlyDatadisConsumptionsBody.java
@@ -1,0 +1,71 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.sync;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Month;
+
+@Schema(requiredProperties = {"year"})
+public class SyncMonthlyDatadisConsumptionsBody {
+
+    @NotNull
+    @Min(value = 2000)
+    @Max(value = 2100)
+    private Integer year;
+
+    @Min(value = 1)
+    @Max(value = 12)
+    private Integer month;
+
+    private String supplyCode;
+
+    public SyncMonthlyDatadisConsumptionsBody() {
+    }
+
+    public SyncMonthlyDatadisConsumptionsBody(Integer year) {
+        this.year = year;
+    }
+
+    public SyncMonthlyDatadisConsumptionsBody(Integer year, Integer month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public SyncMonthlyDatadisConsumptionsBody(Integer year, Integer month, String supplyCode) {
+        this.year = year;
+        this.month = month;
+        this.supplyCode = supplyCode;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+
+    public Integer getMonth() {
+        return month;
+    }
+
+    @JsonIgnore
+    public Month getMonthEnum() {
+        return month != null ? Month.of(month) : null;
+    }
+
+    public void setMonth(Integer month) {
+        this.month = month;
+    }
+
+    public String getSupplyCode() {
+        return supplyCode;
+    }
+
+    public void setSupplyCode(String supplyCode) {
+        this.supplyCode = supplyCode;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncMonthlyDatadisConsumptionsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncMonthlyDatadisConsumptionsController.java
@@ -1,0 +1,105 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.sync;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationService;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Month;
+
+@RestController
+@RequestMapping("/api/v1/consumption/datadis/sync/monthly")
+public class SyncMonthlyDatadisConsumptionsController {
+
+    private final DatadisMonthlyAggregationService aggregationService;
+
+    public SyncMonthlyDatadisConsumptionsController(DatadisMonthlyAggregationService aggregationService) {
+        this.aggregationService = aggregationService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Aggregate hourly Datadis consumption data into monthly totals",
+            description = """
+                    This endpoint enables admins to aggregate hourly consumption data into monthly totals.
+
+                    The request body must contain:
+                    - **year** (required, integer): The year for which to aggregate data
+                    - **month** (optional, integer 1-12): The month to aggregate. If not provided, all months of the year will be aggregated.
+                    - **supplyCode** (optional, string): The supply code (CUPS) to aggregate. If not provided, all active supplies will be aggregated.
+
+                    **Behavior:**
+                    - If both month and supplyCode are provided: Aggregates only that specific supply for that month
+                    - If only month is provided: Aggregates all supplies for that specific month
+                    - If only supplyCode is provided: Aggregates that supply for all months of the year
+                    - If neither month nor supplyCode is provided: Aggregates all supplies for all months of the year
+
+                    Proper authentication, through an authentication token, is required for secure access to this endpoint.
+                    **Required Role: ADMIN**
+
+                    A successful request returns an HTTP status code of 200.
+                    """,
+            tags = ApiTag.CONSUMPTION,
+            operationId = "syncMonthlyDatadisConsumptions",
+            security = @SecurityRequirement(name = "bearerToken", scopes = {"ADMIN"})
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Synchronization executed successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            )
+    })
+    @ForbiddenErrorResponse
+    @UnauthorizedErrorResponse
+    @BadRequestErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("hasRole('ADMIN')")
+    public void syncMonthlyDatadisConsumptions(@Valid @RequestBody SyncMonthlyDatadisConsumptionsBody body) {
+
+        if (body.getSupplyCode() != null && !body.getSupplyCode().isBlank()) {
+            if (body.getMonth() != null) {
+                // Specific supply, specific month
+                aggregationService.aggregateMonthlyConsumptions(
+                        SupplyCode.of(body.getSupplyCode()),
+                        body.getMonthEnum(),
+                        body.getYear()
+                );
+            } else {
+                // Specific supply, all months of year
+                for (Month month : Month.values()) {
+                    aggregationService.aggregateMonthlyConsumptions(
+                            SupplyCode.of(body.getSupplyCode()),
+                            month,
+                            body.getYear()
+                    );
+                }
+            }
+        } else {
+            if (body.getMonth() != null) {
+                // All supplies, specific month
+                aggregationService.aggregateMonthlyConsumptions(body.getMonthEnum(), body.getYear());
+            } else {
+                // All supplies, all months
+                aggregationService.aggregateMonthlyConsumptions(body.getYear());
+            }
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncYearlyDatadisConsumptionsBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncYearlyDatadisConsumptionsBody.java
@@ -1,0 +1,45 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.sync;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(requiredProperties = {"year"})
+public class SyncYearlyDatadisConsumptionsBody {
+
+    @NotNull
+    @Min(value = 2000)
+    @Max(value = 2100)
+    private Integer year;
+
+    private String supplyCode;
+
+    public SyncYearlyDatadisConsumptionsBody() {
+    }
+
+    public SyncYearlyDatadisConsumptionsBody(Integer year) {
+        this.year = year;
+    }
+
+    public SyncYearlyDatadisConsumptionsBody(Integer year, String supplyCode) {
+        this.year = year;
+        this.supplyCode = supplyCode;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+
+    public String getSupplyCode() {
+        return supplyCode;
+    }
+
+    public void setSupplyCode(String supplyCode) {
+        this.supplyCode = supplyCode;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncYearlyDatadisConsumptionsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncYearlyDatadisConsumptionsController.java
@@ -1,0 +1,84 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.sync;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationService;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/consumption/datadis/sync/yearly")
+public class SyncYearlyDatadisConsumptionsController {
+
+    private final DatadisYearlyAggregationService aggregationService;
+
+    public SyncYearlyDatadisConsumptionsController(DatadisYearlyAggregationService aggregationService) {
+        this.aggregationService = aggregationService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Sync monthly Datadis consumption data into yearly totals",
+            description = """
+                    This endpoint enables admins to sync monthly consumption data into yearly totals.
+
+                    The request body must contain:
+                    - **year** (required, integer): The year for which to aggregate data
+                    - **supplyCode** (optional, string): The supply code (CUPS) to aggregate. If not provided, all active supplies will be aggregated.
+
+                    **Behavior:**
+                    - If supplyCode is provided: Aggregates only that specific supply
+                    - If supplyCode is not provided or is empty: Aggregates all active supplies
+
+                    **Note:** This aggregation requires that monthly aggregations have already been performed
+                    for the specified year.
+
+                    Proper authentication, through an authentication token, is required for secure access to this endpoint.
+                    **Required Role: ADMIN**
+
+                    A successful request returns an HTTP status code of 200.
+                    """,
+            tags = ApiTag.CONSUMPTION,
+            operationId = "syncYearlyDatadisConsumptions",
+            security = @SecurityRequirement(name = "bearerToken", scopes = {"ADMIN"})
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Synchronization executed successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            )
+    })
+    @ForbiddenErrorResponse
+    @UnauthorizedErrorResponse
+    @BadRequestErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("hasRole('ADMIN')")
+    public void syncYearlyDatadisConsumptions(@Valid @RequestBody SyncYearlyDatadisConsumptionsBody body) {
+
+        if (body.getSupplyCode() != null && !body.getSupplyCode().isBlank()) {
+            aggregationService.aggregateYearlyConsumptions(
+                    SupplyCode.of(body.getSupplyCode()),
+                    body.getYear()
+            );
+        } else {
+            aggregationService.aggregateYearlyConsumptions(body.getYear());
+        }
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/architecture/ServiceTransactionalArchTest.java
+++ b/src/test/java/org/lucoenergia/conluz/architecture/ServiceTransactionalArchTest.java
@@ -8,6 +8,8 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationService;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationService;
 import org.lucoenergia.conluz.domain.consumption.datadis.sync.DatadisConsumptionSyncService;
 import org.lucoenergia.conluz.domain.price.sync.SyncDailyPricesService;
 import org.lucoenergia.conluz.domain.production.huawei.sync.SyncHuaweiProductionService;
@@ -59,6 +61,8 @@ public class ServiceTransactionalArchTest {
         addException(SyncDailyPricesService.class.getSimpleName());
         addException(SyncHuaweiProductionService.class.getSimpleName());
         addException(ShellyConsumptionsHourlyAggregatorService.class.getSimpleName());
+        addException(DatadisMonthlyAggregationService.class.getSimpleName());
+        addException(DatadisYearlyAggregationService.class.getSimpleName());
         // Add more exceptions as needed
     }
 

--- a/src/test/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisMonthlyAggregationServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisMonthlyAggregationServiceTest.java
@@ -1,0 +1,193 @@
+package org.lucoenergia.conluz.domain.consumption.datadis.aggregate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate.DatadisMonthlyAggregationServiceImpl;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Month;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@Transactional
+class DatadisMonthlyAggregationServiceTest extends BaseIntegrationTest {
+
+    private final DatadisMonthlyAggregationRepository aggregationRepository =
+            Mockito.mock(DatadisMonthlyAggregationRepository.class);
+
+    @Autowired
+    private GetSupplyRepository getSupplyRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreateUserRepository createUserRepository;
+
+    private DatadisMonthlyAggregationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DatadisMonthlyAggregationServiceImpl(getSupplyRepository, aggregationRepository);
+    }
+
+    @Test
+    void testAggregateMonthlyForAllSuppliesAllMonths() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply1 = SupplyMother.random()
+                .withDistributorCode("DIST001")
+                .build();
+        supply1 = createSupplyRepository.create(supply1, UserId.of(user.getId()));
+
+        Supply supply2 = SupplyMother.random()
+                .withDistributorCode("DIST002")
+                .build();
+        supply2 = createSupplyRepository.create(supply2, UserId.of(user.getId()));
+
+        // When
+        service.aggregateMonthlyConsumptions(2024);
+
+        // Then - Should call repository for each supply × 12 months = 24 times
+        verify(aggregationRepository, times(24))
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForSpecificSupplyAndMonth() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply = SupplyMother.random()
+                .withDistributorCode("DIST123")
+                .build();
+        supply = createSupplyRepository.create(supply, UserId.of(user.getId()));
+
+        // When
+        service.aggregateMonthlyConsumptions(SupplyCode.of(supply.getCode()), Month.JUNE, 2024);
+
+        // Then
+        verify(aggregationRepository, times(1))
+                .aggregateMonthlyConsumption(eq(supply), eq(Month.JUNE), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForAllSuppliesSpecificMonth() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply1 = SupplyMother.random()
+                .withDistributorCode("DIST001")
+                .build();
+        supply1 = createSupplyRepository.create(supply1, UserId.of(user.getId()));
+
+        Supply supply2 = SupplyMother.random()
+                .withDistributorCode("DIST002")
+                .build();
+        supply2 = createSupplyRepository.create(supply2, UserId.of(user.getId()));
+
+        // When
+        service.aggregateMonthlyConsumptions(Month.DECEMBER, 2024);
+
+        // Then - Should call repository for each supply × 1 month = 2 times
+        verify(aggregationRepository, times(2))
+                .aggregateMonthlyConsumption(any(Supply.class), eq(Month.DECEMBER), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlySkipsSuppliesWithoutDistributorCode() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supplyWithCode = SupplyMother.random()
+                .withDistributorCode("DIST001")
+                .build();
+        supplyWithCode = createSupplyRepository.create(supplyWithCode, UserId.of(user.getId()));
+
+        Supply supplyWithoutCode = SupplyMother.random()
+                .withDistributorCode(null)
+                .build();
+        supplyWithoutCode = createSupplyRepository.create(supplyWithoutCode, UserId.of(user.getId()));
+
+        // When
+        service.aggregateMonthlyConsumptions(Month.JANUARY, 2024);
+
+        // Then - Should only call for supply with distributor code
+        verify(aggregationRepository, times(1))
+                .aggregateMonthlyConsumption(eq(supplyWithCode), eq(Month.JANUARY), eq(2024));
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(eq(supplyWithoutCode), any(Month.class), anyInt());
+    }
+
+    @Test
+    void testAggregateMonthlyWithSupplyNotFoundException() {
+
+        // Given - no supplies created
+
+        // When & Then
+        assertThrows(SupplyNotFoundException.class, () ->
+                service.aggregateMonthlyConsumptions(SupplyCode.of("INVALID"), Month.JUNE, 2024)
+        );
+
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+    }
+
+    @Test
+    void testAggregateMonthlyHandlesRepositoryException() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply = SupplyMother.random()
+                .withDistributorCode("DIST123")
+                .build();
+        supply = createSupplyRepository.create(supply, UserId.of(user.getId()));
+
+        doThrow(new RuntimeException("InfluxDB connection error"))
+                .when(aggregationRepository)
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+
+        // When - Should not throw exception, just log error
+        service.aggregateMonthlyConsumptions(Month.JUNE, 2024);
+
+        // Then - Should have attempted to aggregate
+        verify(aggregationRepository, times(1))
+                .aggregateMonthlyConsumption(eq(supply), eq(Month.JUNE), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyWithEmptySupplyList() {
+
+        // Given - no supplies created
+
+        // When
+        service.aggregateMonthlyConsumptions(2024);
+
+        // Then - Should not call repository
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisYearlyAggregationServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/consumption/datadis/aggregate/DatadisYearlyAggregationServiceTest.java
@@ -1,0 +1,166 @@
+package org.lucoenergia.conluz.domain.consumption.datadis.aggregate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate.DatadisYearlyAggregationServiceImpl;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@Transactional
+class DatadisYearlyAggregationServiceTest extends BaseIntegrationTest {
+
+    private final DatadisYearlyAggregationRepository aggregationRepository =
+            Mockito.mock(DatadisYearlyAggregationRepository.class);
+
+    @Autowired
+    private GetSupplyRepository getSupplyRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreateUserRepository createUserRepository;
+
+    private DatadisYearlyAggregationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DatadisYearlyAggregationServiceImpl(getSupplyRepository, aggregationRepository);
+    }
+
+    @Test
+    void testAggregateYearlyForAllSupplies() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply1 = SupplyMother.random()
+                .withDistributorCode("DIST001")
+                .build();
+        supply1 = createSupplyRepository.create(supply1, UserId.of(user.getId()));
+
+        Supply supply2 = SupplyMother.random()
+                .withDistributorCode("DIST002")
+                .build();
+        supply2 = createSupplyRepository.create(supply2, UserId.of(user.getId()));
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - Should call repository for each supply = 2 times
+        verify(aggregationRepository, times(2))
+                .aggregateYearlyConsumption(any(Supply.class), eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlyForSpecificSupply() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply = SupplyMother.random()
+                .withDistributorCode("DIST123")
+                .build();
+        supply = createSupplyRepository.create(supply, UserId.of(user.getId()));
+
+        // When
+        service.aggregateYearlyConsumptions(SupplyCode.of(supply.getCode()), 2024);
+
+        // Then
+        verify(aggregationRepository, times(1))
+                .aggregateYearlyConsumption(eq(supply), eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlySkipsSuppliesWithoutDistributorCode() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supplyWithCode = SupplyMother.random()
+                .withDistributorCode("DIST001")
+                .build();
+        supplyWithCode = createSupplyRepository.create(supplyWithCode, UserId.of(user.getId()));
+
+        Supply supplyWithoutCode = SupplyMother.random()
+                .withDistributorCode(null)
+                .build();
+        supplyWithoutCode = createSupplyRepository.create(supplyWithoutCode, UserId.of(user.getId()));
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - Should only call for supply with distributor code
+        verify(aggregationRepository, times(1))
+                .aggregateYearlyConsumption(eq(supplyWithCode), eq(2024));
+        verify(aggregationRepository, never())
+                .aggregateYearlyConsumption(eq(supplyWithoutCode), anyInt());
+    }
+
+    @Test
+    void testAggregateYearlyWithSupplyNotFoundException() {
+
+        // Given - no supplies created
+
+        // When & Then
+        assertThrows(SupplyNotFoundException.class, () ->
+                service.aggregateYearlyConsumptions(SupplyCode.of("INVALID"), 2024)
+        );
+
+        verify(aggregationRepository, never())
+                .aggregateYearlyConsumption(any(Supply.class), anyInt());
+    }
+
+    @Test
+    void testAggregateYearlyHandlesRepositoryException() {
+
+        // Given
+        User user = UserMother.randomUser();
+        user = createUserRepository.create(user);
+
+        Supply supply = SupplyMother.random()
+                .withDistributorCode("DIST123")
+                .build();
+        supply = createSupplyRepository.create(supply, UserId.of(user.getId()));
+
+        doThrow(new RuntimeException("InfluxDB connection error"))
+                .when(aggregationRepository)
+                .aggregateYearlyConsumption(any(Supply.class), anyInt());
+
+        // When - Should not throw exception, just log error
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - Should have attempted to aggregate
+        verify(aggregationRepository, times(1))
+                .aggregateYearlyConsumption(eq(supply), eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlyWithEmptySupplyList() {
+
+        // Given - no supplies created
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - Should not call repository
+        verify(aggregationRepository, never())
+                .aggregateYearlyConsumption(any(Supply.class), anyInt());
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/domain/consumption/datadis/sync/DatadisConsumptionSyncServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/consumption/datadis/sync/DatadisConsumptionSyncServiceTest.java
@@ -19,8 +19,6 @@ import org.lucoenergia.conluz.domain.shared.UserId;
 import org.lucoenergia.conluz.infrastructure.admin.supply.DatadisSupplyConfigurationException;
 import org.lucoenergia.conluz.infrastructure.consumption.datadis.sync.DatadisConsumptionSyncServiceImpl;
 import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
-import org.lucoenergia.conluz.infrastructure.shared.time.DateConverter;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +27,6 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -46,15 +43,13 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
     private CreateSupplyRepository createSupplyRepository;
     @Autowired
     private CreateUserRepository createUserRepository;
-    @Autowired
-    private DateConverter dateConverter;
 
     private DatadisConsumptionSyncService service;
 
     @BeforeEach
     void setUp() {
         service = new DatadisConsumptionSyncServiceImpl(getDatadisConsumptionRepository,
-                getSupplyRepository, persistDatadisConsumptionRepository, dateConverter);
+                getSupplyRepository, persistDatadisConsumptionRepository);
     }
 
     @Test
@@ -86,8 +81,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(1))
                 .getHourlyConsumptionsByMonth(eq(supply), eq(Month.FEBRUARY), eq(2024));
         verify(persistDatadisConsumptionRepository, times(1)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -121,8 +114,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(1))
                 .getHourlyConsumptionsByMonth(eq(supply), eq(Month.MAY), eq(2024));
         verify(persistDatadisConsumptionRepository, times(3)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -150,8 +141,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(12))
                 .getHourlyConsumptionsByMonth(eq(supply), any(Month.class), eq(2024));
         verify(persistDatadisConsumptionRepository, times(12)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -187,8 +176,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(1))
                 .getHourlyConsumptionsByMonth(eq(supply), eq(Month.FEBRUARY), eq(2024));
         verify(persistDatadisConsumptionRepository, times(4)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -232,8 +219,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(3))
                 .getHourlyConsumptionsByMonth(eq(supply), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, times(2)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -266,8 +251,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(3))
                 .getHourlyConsumptionsByMonth(eq(supply), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, times(2)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -338,8 +321,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, never())
                 .getHourlyConsumptionsByMonth(any(Supply.class), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, never()).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -373,146 +354,8 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, never())
                 .getHourlyConsumptionsByMonth(any(Supply.class), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, never()).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistYearlyConsumptions(anyList());
     }
 
-    @Test
-    void testMonthlyAggregationCalculatesCorrectSums() {
-
-        // Given
-        User user = UserMother.randomUser();
-        user = createUserRepository.create(user);
-
-        Supply supply = SupplyMother.random()
-                .withDistributorCode("AGGTEST")
-                .build();
-        createSupplyRepository.create(supply, UserId.of(user.getId()));
-
-        DatadisConsumption hour1 = new DatadisConsumption();
-        hour1.setCups("ES1234567890");
-        hour1.setDate("2024/01");
-        hour1.setTime("01:00");
-        hour1.setObtainMethod("Real");
-        hour1.setConsumptionKWh(10.5f);
-        hour1.setSurplusEnergyKWh(2.3f);
-        hour1.setGenerationEnergyKWh(5.1f);
-        hour1.setSelfConsumptionEnergyKWh(3.2f);
-
-        DatadisConsumption hour2 = new DatadisConsumption();
-        hour2.setCups("ES1234567890");
-        hour2.setDate("2024/01");
-        hour2.setTime("02:00");
-        hour2.setObtainMethod("Real");
-        hour2.setConsumptionKWh(8.2f);
-        hour2.setSurplusEnergyKWh(1.8f);
-        hour2.setGenerationEnergyKWh(4.5f);
-        hour2.setSelfConsumptionEnergyKWh(2.7f);
-
-        DatadisConsumption hour3 = new DatadisConsumption();
-        hour3.setCups("ES1234567890");
-        hour3.setDate("2024/01");
-        hour3.setTime("03:00");
-        hour3.setObtainMethod("Real");
-        hour3.setConsumptionKWh(12.1f);
-        hour3.setSurplusEnergyKWh(3.1f);
-        hour3.setGenerationEnergyKWh(6.2f);
-        hour3.setSelfConsumptionEnergyKWh(4.0f);
-
-        List<DatadisConsumption> hourlyConsumptions = List.of(hour1, hour2, hour3);
-
-        when(getDatadisConsumptionRepository.getHourlyConsumptionsByMonth(any(Supply.class), any(Month.class), anyInt()))
-                .thenReturn(hourlyConsumptions);
-
-        ArgumentCaptor<List<DatadisConsumption>> monthlyCaptor = ArgumentCaptor.forClass(List.class);
-
-        // When
-        LocalDate startDate = LocalDate.of(2024, 1, 1);
-        LocalDate endDate = LocalDate.of(2024, 1, 31);
-        service.synchronizeConsumptions(startDate, endDate);
-
-        // Then
-        verify(persistDatadisConsumptionRepository).persistMonthlyConsumptions(monthlyCaptor.capture());
-
-        List<DatadisConsumption> monthlyAggregated = monthlyCaptor.getValue();
-        assertEquals(1, monthlyAggregated.size());
-
-        DatadisConsumption monthly = monthlyAggregated.get(0);
-        assertEquals(30.8f, monthly.getConsumptionKWh(), 0.01f);
-        assertEquals(7.2f, monthly.getSurplusEnergyKWh(), 0.01f);
-        assertEquals(15.8f, monthly.getGenerationEnergyKWh(), 0.01f);
-        assertEquals(9.9f, monthly.getSelfConsumptionEnergyKWh(), 0.01f);
-        assertEquals("ES1234567890", monthly.getCups());
-        assertEquals("2024/01", monthly.getDate());
-        assertEquals("Real", monthly.getObtainMethod());
-    }
-
-    @Test
-    void testAggregationHandlesNullValuesCorrectly() {
-
-        // Given
-        User user = UserMother.randomUser();
-        user = createUserRepository.create(user);
-
-        Supply supply = SupplyMother.random()
-                .withDistributorCode("NULLTEST")
-                .build();
-        createSupplyRepository.create(supply, UserId.of(user.getId()));
-
-        DatadisConsumption hour1 = new DatadisConsumption();
-        hour1.setCups("ES1234567890");
-        hour1.setDate("2024/01");
-        hour1.setTime("01:00");
-        hour1.setObtainMethod("Real");
-        hour1.setConsumptionKWh(10.0f);
-        hour1.setSurplusEnergyKWh(null);
-        hour1.setGenerationEnergyKWh(5.0f);
-        hour1.setSelfConsumptionEnergyKWh(3.0f);
-
-        DatadisConsumption hour2 = new DatadisConsumption();
-        hour2.setCups("ES1234567890");
-        hour2.setDate("2024/01");
-        hour2.setTime("02:00");
-        hour2.setObtainMethod("Real");
-        hour2.setConsumptionKWh(8.0f);
-        hour2.setSurplusEnergyKWh(2.0f);
-        hour2.setGenerationEnergyKWh(null);
-        hour2.setSelfConsumptionEnergyKWh(2.0f);
-
-        DatadisConsumption hour3 = new DatadisConsumption();
-        hour3.setCups("ES1234567890");
-        hour3.setDate("2024/01");
-        hour3.setTime("03:00");
-        hour3.setObtainMethod("Real");
-        hour3.setConsumptionKWh(null);
-        hour3.setSurplusEnergyKWh(1.5f);
-        hour3.setGenerationEnergyKWh(4.0f);
-        hour3.setSelfConsumptionEnergyKWh(null);
-
-        List<DatadisConsumption> hourlyConsumptions = List.of(hour1, hour2, hour3);
-
-        when(getDatadisConsumptionRepository.getHourlyConsumptionsByMonth(any(Supply.class), any(Month.class), anyInt()))
-                .thenReturn(hourlyConsumptions);
-
-        ArgumentCaptor<List<DatadisConsumption>> monthlyCaptor = ArgumentCaptor.forClass(List.class);
-
-        // When
-        LocalDate startDate = LocalDate.of(2024, 1, 1);
-        LocalDate endDate = LocalDate.of(2024, 1, 31);
-        service.synchronizeConsumptions(startDate, endDate);
-
-        // Then
-        verify(persistDatadisConsumptionRepository).persistMonthlyConsumptions(monthlyCaptor.capture());
-
-        List<DatadisConsumption> monthlyAggregated = monthlyCaptor.getValue();
-        assertEquals(1, monthlyAggregated.size());
-
-        DatadisConsumption monthly = monthlyAggregated.get(0);
-        assertEquals(18.0f, monthly.getConsumptionKWh(), 0.01f);
-        assertEquals(3.5f, monthly.getSurplusEnergyKWh(), 0.01f);
-        assertEquals(9.0f, monthly.getGenerationEnergyKWh(), 0.01f);
-        assertEquals(5.0f, monthly.getSelfConsumptionEnergyKWh(), 0.01f);
-    }
 
     @Test
     void testSynchronizeConsumptionsSkipsSupplyWithBlankDistributorCode() {
@@ -572,8 +415,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(1))
                 .getHourlyConsumptionsByMonth(eq(supply), eq(Month.JANUARY), eq(2024));
         verify(persistDatadisConsumptionRepository, times(1)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -600,94 +441,8 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(1))
                 .getHourlyConsumptionsByMonth(eq(supply), eq(Month.JANUARY), eq(2024));
         verify(persistDatadisConsumptionRepository, times(0)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(0)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(0)).persistYearlyConsumptions(anyList());
     }
 
-    @Test
-    void testYearlyAggregationCalculatesCorrectSumsAcrossYears() {
-        // Given
-        User user = UserMother.randomUser();
-        user = createUserRepository.create(user);
-
-        Supply supply = SupplyMother.random()
-                .withDistributorCode("YEARTEST")
-                .build();
-        supply = createSupplyRepository.create(supply, UserId.of(user.getId()));
-
-        // December 2023
-        DatadisConsumption dec2023 = new DatadisConsumption();
-        dec2023.setCups("ES1234567890");
-        dec2023.setDate("2023/12");
-        dec2023.setTime("00:00");
-        dec2023.setObtainMethod("Real");
-        dec2023.setConsumptionKWh(100.0f);
-        dec2023.setSurplusEnergyKWh(10.0f);
-        dec2023.setGenerationEnergyKWh(50.0f);
-        dec2023.setSelfConsumptionEnergyKWh(40.0f);
-
-        // January 2024
-        DatadisConsumption jan2024 = new DatadisConsumption();
-        jan2024.setCups("ES1234567890");
-        jan2024.setDate("2024/01");
-        jan2024.setTime("00:00");
-        jan2024.setObtainMethod("Real");
-        jan2024.setConsumptionKWh(150.0f);
-        jan2024.setSurplusEnergyKWh(15.0f);
-        jan2024.setGenerationEnergyKWh(75.0f);
-        jan2024.setSelfConsumptionEnergyKWh(60.0f);
-
-        // February 2024
-        DatadisConsumption feb2024 = new DatadisConsumption();
-        feb2024.setCups("ES1234567890");
-        feb2024.setDate("2024/02");
-        feb2024.setTime("00:00");
-        feb2024.setObtainMethod("Real");
-        feb2024.setConsumptionKWh(200.0f);
-        feb2024.setSurplusEnergyKWh(20.0f);
-        feb2024.setGenerationEnergyKWh(100.0f);
-        feb2024.setSelfConsumptionEnergyKWh(80.0f);
-
-        when(getDatadisConsumptionRepository.getHourlyConsumptionsByMonth(eq(supply), eq(Month.DECEMBER), eq(2023)))
-                .thenReturn(List.of(dec2023));
-        when(getDatadisConsumptionRepository.getHourlyConsumptionsByMonth(eq(supply), eq(Month.JANUARY), eq(2024)))
-                .thenReturn(List.of(jan2024));
-        when(getDatadisConsumptionRepository.getHourlyConsumptionsByMonth(eq(supply), eq(Month.FEBRUARY), eq(2024)))
-                .thenReturn(List.of(feb2024));
-
-        ArgumentCaptor<List<DatadisConsumption>> yearlyCaptor = ArgumentCaptor.forClass(List.class);
-
-        // When
-        LocalDate startDate = LocalDate.of(2023, 12, 1);
-        LocalDate endDate = LocalDate.of(2024, 2, 28);
-        service.synchronizeConsumptions(startDate, endDate);
-
-        // Then
-        verify(persistDatadisConsumptionRepository).persistYearlyConsumptions(yearlyCaptor.capture());
-
-        List<DatadisConsumption> yearlyAggregated = yearlyCaptor.getValue();
-        assertEquals(2, yearlyAggregated.size());
-
-        DatadisConsumption year2023 = yearlyAggregated.get(0);
-        assertEquals(100.0f, year2023.getConsumptionKWh(), 0.01f);
-        assertEquals(10.0f, year2023.getSurplusEnergyKWh(), 0.01f);
-        assertEquals(50.0f, year2023.getGenerationEnergyKWh(), 0.01f);
-        assertEquals(40.0f, year2023.getSelfConsumptionEnergyKWh(), 0.01f);
-        assertEquals("ES1234567890", year2023.getCups());
-        assertEquals("2023/12/31", year2023.getDate());
-        assertEquals("00:00", year2023.getTime());
-        assertEquals("Real", year2023.getObtainMethod());
-
-        DatadisConsumption year2024 = yearlyAggregated.get(1);
-        assertEquals(350.0f, year2024.getConsumptionKWh(), 0.01f);
-        assertEquals(35.0f, year2024.getSurplusEnergyKWh(), 0.01f);
-        assertEquals(175.0f, year2024.getGenerationEnergyKWh(), 0.01f);
-        assertEquals(140.0f, year2024.getSelfConsumptionEnergyKWh(), 0.01f);
-        assertEquals("ES1234567890", year2024.getCups());
-        assertEquals("2024/12/31", year2024.getDate());
-        assertEquals("00:00", year2024.getTime());
-        assertEquals("Real", year2024.getObtainMethod());
-    }
 
     @Test
     void testSynchronizeConsumptionsForSingleSupplyWithValidCode() {
@@ -723,8 +478,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, never())
                 .getHourlyConsumptionsByMonth(eq(supply2), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, times(1)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -742,8 +495,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, never())
                 .getHourlyConsumptionsByMonth(any(Supply.class), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, never()).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -768,8 +519,6 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, never())
                 .getHourlyConsumptionsByMonth(any(Supply.class), any(Month.class), anyInt());
         verify(persistDatadisConsumptionRepository, never()).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, never()).persistYearlyConsumptions(anyList());
     }
 
     @Test
@@ -804,7 +553,5 @@ class DatadisConsumptionSyncServiceTest extends BaseIntegrationTest {
         verify(getDatadisConsumptionRepository, times(1))
                 .getHourlyConsumptionsByMonth(eq(supply), eq(Month.MAY), eq(2024));
         verify(persistDatadisConsumptionRepository, times(3)).persistHourlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistMonthlyConsumptions(anyList());
-        verify(persistDatadisConsumptionRepository, times(1)).persistYearlyConsumptions(anyList());
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionInfluxLoader.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/DatadisConsumptionInfluxLoader.java
@@ -3,6 +3,7 @@ package org.lucoenergia.conluz.infrastructure.consumption.datadis;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
 import org.lucoenergia.conluz.infrastructure.consumption.datadis.config.DatadisConfigEntity;
 import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxDbConnectionManager;
 import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxLoader;
@@ -179,6 +180,15 @@ public class DatadisConsumptionInfluxLoader implements InfluxLoader {
 
     @Override
     public void clearData() {
-        // InfluxDB test container is recreated for each test, so no need to clear data
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            for (String measurement : List.of(
+                    DatadisConfigEntity.CONSUMPTION_KWH_MEASUREMENT,
+                    DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT,
+                    DatadisConfigEntity.CONSUMPTION_KWH_YEAR_MEASUREMENT)) {
+                connection.query(new Query(String.format(
+                        "DROP SERIES FROM \"%s\" WHERE \"cups\" = '%s'",
+                        measurement, CUPS_CODE)));
+            }
+        }
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationJobTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationJobTest.java
@@ -1,0 +1,31 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationService;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class DatadisMonthlyAggregationJobTest {
+
+    @Test
+    void testRun_ShouldCallServiceWithPreviousMonth() {
+        // Arrange
+        DatadisMonthlyAggregationService mockService = Mockito.mock(DatadisMonthlyAggregationService.class);
+        DatadisMonthlyAggregationJob job = new DatadisMonthlyAggregationJob(mockService);
+
+        LocalDate today = LocalDate.now();
+        Month month = today.getMonth();
+        int year = today.getYear();
+
+        // Act
+        job.run();
+
+        // Assert
+        verify(mockService, times(1)).aggregateMonthlyConsumptions(month, year);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationRepositoryInfluxTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationRepositoryInfluxTest.java
@@ -1,0 +1,219 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.influxdb.impl.InfluxDBResultMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationRepository;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.DatadisConsumptionMonthlyPoint;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.config.DatadisConfigEntity;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxDbConnectionManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Month;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for DatadisMonthlyAggregationRepositoryInflux.
+ * <p>
+ * Test data: 30 hourly records for April 2023 (24 for April 1 + 6 for April 2).
+ * Expected sums after aggregation:
+ *   consumption_kwh:         15.57 (13.31 April 1 + 2.26 April 2)
+ *   surplus_energy_kwh:       1.93 (only April 1 has solar production)
+ *   self_consumption_energy_kwh: 2.37 (only April 1 has self-consumption)
+ * <p>
+ * The aggregated record timestamp is the first day of April 2023 at midnight local time (Europe/Madrid),
+ * which is 2023-03-31T22:00:00Z in UTC.
+ */
+@SpringBootTest
+class DatadisMonthlyAggregationRepositoryInfluxTest extends BaseIntegrationTest {
+
+    private static final String CUPS_CODE = "ES0031406912345678JN0F";
+
+    @Autowired
+    private DatadisMonthlyAggregationRepository repository;
+
+    @Autowired
+    private InfluxDbConnectionManager influxDbConnectionManager;
+
+    private Supply supply;
+
+    @BeforeEach
+    void setUp() {
+        User user = UserMother.randomUser();
+        supply = SupplyMother.random(user).withCode(CUPS_CODE).build();
+        loadHourlyDataForApril2023();
+    }
+
+    @AfterEach
+    void tearDown() {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            for (String measurement : List.of(
+                    DatadisConfigEntity.CONSUMPTION_KWH_MEASUREMENT,
+                    DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT)) {
+                connection.query(new Query(String.format(
+                        "DROP SERIES FROM \"%s\" WHERE \"cups\" = '%s'",
+                        measurement, CUPS_CODE)));
+            }
+        }
+    }
+
+    @Test
+    void testAggregateMonthlyConsumptionComputesCorrectSums() {
+
+        // When
+        repository.aggregateMonthlyConsumption(supply, Month.APRIL, 2023);
+
+        // Then - query using a window wide enough to capture the April 1 midnight in any timezone
+        List<DatadisConsumptionMonthlyPoint> result = queryMonthlyData(
+                "2023-03-31T20:00:00Z", "2023-04-01T04:00:00Z");
+
+        assertFalse(result.isEmpty(), "Expected aggregated monthly data to be written for April 2023");
+        assertEquals(1, result.size());
+
+        DatadisConsumptionMonthlyPoint point = result.get(0);
+        assertEquals(CUPS_CODE, point.getCups());
+
+        // April 1 sum: 13.31 + April 2 sum: 2.26 = 15.57
+        assertNotNull(point.getConsumptionKWh());
+        assertEquals(15.57, point.getConsumptionKWh(), 0.01,
+                "Total consumption should be the sum of all hourly records for April 2023");
+
+        // Surplus only on April 1 = 1.93
+        assertNotNull(point.getSurplusEnergyKWh());
+        assertEquals(1.93, point.getSurplusEnergyKWh(), 0.01,
+                "Total surplus should be the sum of all hourly surplus values for April 2023");
+
+        // Self-consumption only on April 1 = 2.37
+        assertNotNull(point.getSelfConsumptionEnergyKWh());
+        assertEquals(2.37, point.getSelfConsumptionEnergyKWh(), 0.01,
+                "Total self-consumption should be the sum of all hourly self-consumption values for April 2023");
+
+        assertNotNull(point.getObtainMethod());
+        assertEquals("Real", point.getObtainMethod());
+    }
+
+    @Test
+    void testAggregateMonthlyConsumptionSetsTimestampToFirstDayOfMonth() {
+
+        // When
+        repository.aggregateMonthlyConsumption(supply, Month.APRIL, 2023);
+
+        // Then - the aggregated point must exist at first day of April midnight (local timezone)
+        // April 1, 2023 00:00:00 Europe/Madrid (UTC+2) = 2023-03-31T22:00:00Z
+        List<DatadisConsumptionMonthlyPoint> inWindow = queryMonthlyData(
+                "2023-03-31T20:00:00Z", "2023-04-01T04:00:00Z");
+
+        assertFalse(inWindow.isEmpty(),
+                "Aggregated point should be stored at the first day of the month at midnight (local time)");
+
+        // Verify it does NOT appear in the previous month's window
+        List<DatadisConsumptionMonthlyPoint> previousMonth = queryMonthlyData(
+                "2023-03-01T00:00:00Z", "2023-03-31T19:59:59Z");
+
+        assertTrue(previousMonth.isEmpty(),
+                "Aggregated point must not appear in the previous month's time window");
+    }
+
+    @Test
+    void testAggregateMonthlyConsumptionWithNoHourlyDataDoesNotWrite() {
+
+        // When - aggregate for January 2023, which has no hourly data loaded
+        repository.aggregateMonthlyConsumption(supply, Month.JANUARY, 2023);
+
+        // Then - nothing should be written to the monthly measurement for January 2023
+        List<DatadisConsumptionMonthlyPoint> result = queryMonthlyData(
+                "2022-12-31T20:00:00Z", "2023-01-01T04:00:00Z");
+
+        assertTrue(result.isEmpty(),
+                "No monthly data should be written when there is no hourly source data");
+    }
+
+    // -----------------------------------------------------------------------
+    // Data setup helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Loads 30 hourly records for April 2023 (same data as DatadisConsumptionInfluxLoader).
+     * 24 records for April 1 and 6 records for April 2.
+     */
+    private void loadHourlyDataForApril2023() {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            BatchPoints batchPoints = influxDbConnectionManager.createBatchPoints();
+
+            // April 1, 2023 - 24 hourly records
+            loadHourlyPoint(batchPoints, 1680307200000000000L, 0.45, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680310800000000000L, 0.42, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680314400000000000L, 0.38, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680318000000000000L, 0.35, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680321600000000000L, 0.33, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680325200000000000L, 0.32, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680328800000000000L, 0.40, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680332400000000000L, 0.55, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680336000000000000L, 0.68, 0.10, 0.15);
+            loadHourlyPoint(batchPoints, 1680339600000000000L, 0.72, 0.20, 0.25);
+            loadHourlyPoint(batchPoints, 1680343200000000000L, 0.75, 0.25, 0.30);
+            loadHourlyPoint(batchPoints, 1680346800000000000L, 0.78, 0.30, 0.35);
+            loadHourlyPoint(batchPoints, 1680350400000000000L, 0.80, 0.35, 0.40);
+            loadHourlyPoint(batchPoints, 1680354000000000000L, 0.76, 0.28, 0.33);
+            loadHourlyPoint(batchPoints, 1680357600000000000L, 0.70, 0.22, 0.27);
+            loadHourlyPoint(batchPoints, 1680361200000000000L, 0.65, 0.15, 0.20);
+            loadHourlyPoint(batchPoints, 1680364800000000000L, 0.58, 0.08, 0.12);
+            loadHourlyPoint(batchPoints, 1680368400000000000L, 0.50, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680372000000000000L, 0.55, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680375600000000000L, 0.60, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680379200000000000L, 0.58, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680382800000000000L, 0.52, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680386400000000000L, 0.48, 0.0,  0.0);
+            loadHourlyPoint(batchPoints, 1680390000000000000L, 0.46, 0.0,  0.0);
+
+            // April 2, 2023 - 6 hourly records
+            loadHourlyPoint(batchPoints, 1680393600000000000L, 0.44, 0.0, 0.0);
+            loadHourlyPoint(batchPoints, 1680397200000000000L, 0.40, 0.0, 0.0);
+            loadHourlyPoint(batchPoints, 1680400800000000000L, 0.37, 0.0, 0.0);
+            loadHourlyPoint(batchPoints, 1680404400000000000L, 0.36, 0.0, 0.0);
+            loadHourlyPoint(batchPoints, 1680408000000000000L, 0.34, 0.0, 0.0);
+            loadHourlyPoint(batchPoints, 1680411600000000000L, 0.35, 0.0, 0.0);
+
+            connection.write(batchPoints);
+        }
+    }
+
+    private void loadHourlyPoint(BatchPoints batchPoints, long timestampNanos,
+                                  double consumption, double surplus, double selfConsumption) {
+        batchPoints.point(Point.measurement(DatadisConfigEntity.CONSUMPTION_KWH_MEASUREMENT)
+                .time(timestampNanos, TimeUnit.NANOSECONDS)
+                .tag("cups", CUPS_CODE)
+                .addField("consumption_kwh", consumption)
+                .addField("surplus_energy_kwh", surplus)
+                .addField("self_consumption_energy_kwh", selfConsumption)
+                .addField("generation_energy_kwh", 0.0)
+                .addField("obtain_method", "Real")
+                .build());
+    }
+
+    private List<DatadisConsumptionMonthlyPoint> queryMonthlyData(String startDate, String endDate) {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            Query query = new Query(String.format(
+                    "SELECT * FROM \"%s\" WHERE cups = '%s' AND time >= '%s' AND time <= '%s'",
+                    DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT, CUPS_CODE, startDate, endDate));
+            QueryResult result = connection.query(query);
+            InfluxDBResultMapper mapper = new InfluxDBResultMapper();
+            return mapper.toPOJO(result, DatadisConsumptionMonthlyPoint.class);
+        }
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisMonthlyAggregationServiceImplTest.java
@@ -1,0 +1,178 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Month;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DatadisMonthlyAggregationServiceImplTest {
+
+    @Mock
+    private GetSupplyRepository getSupplyRepository;
+
+    @Mock
+    private DatadisMonthlyAggregationRepository aggregationRepository;
+
+    @InjectMocks
+    private DatadisMonthlyAggregationServiceImpl service;
+
+    @Test
+    void testAggregateMonthlyForAllSuppliesAllMonths() {
+
+        // Given
+        Supply supply1 = SupplyMother.random().withDistributorCode("DIST001").build();
+        Supply supply2 = SupplyMother.random().withDistributorCode("DIST002").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supply1, supply2));
+
+        // When
+        service.aggregateMonthlyConsumptions(2024);
+
+        // Then - 2 supplies × 12 months = 24 calls
+        verify(aggregationRepository, times(24))
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForAllSuppliesSpecificMonth() {
+
+        // Given
+        Supply supply1 = SupplyMother.random().withDistributorCode("DIST001").build();
+        Supply supply2 = SupplyMother.random().withDistributorCode("DIST002").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supply1, supply2));
+
+        // When
+        service.aggregateMonthlyConsumptions(Month.DECEMBER, 2024);
+
+        // Then - 2 supplies × 1 month = 2 calls
+        verify(aggregationRepository, times(2))
+                .aggregateMonthlyConsumption(any(Supply.class), eq(Month.DECEMBER), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForSpecificSupplyAndMonth() {
+
+        // Given
+        Supply supply = SupplyMother.random().withDistributorCode("DIST123").build();
+        SupplyCode supplyCode = SupplyCode.of(supply.getCode());
+        when(getSupplyRepository.findByCode(supplyCode)).thenReturn(Optional.of(supply));
+
+        // When
+        service.aggregateMonthlyConsumptions(supplyCode, Month.JUNE, 2024);
+
+        // Then
+        verify(aggregationRepository, times(1))
+                .aggregateMonthlyConsumption(eq(supply), eq(Month.JUNE), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlySkipsSuppliesWithoutDistributorCode() {
+
+        // Given
+        Supply supplyWithCode = SupplyMother.random().withDistributorCode("DIST001").build();
+        Supply supplyWithoutCode = SupplyMother.random().withDistributorCode(null).build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supplyWithCode, supplyWithoutCode));
+
+        // When
+        service.aggregateMonthlyConsumptions(Month.JANUARY, 2024);
+
+        // Then - only the supply with a distributor code is processed
+        verify(aggregationRepository, times(1))
+                .aggregateMonthlyConsumption(eq(supplyWithCode), eq(Month.JANUARY), eq(2024));
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(eq(supplyWithoutCode), any(Month.class), anyInt());
+    }
+
+    @Test
+    void testAggregateMonthlySkipsSuppliesWithBlankDistributorCode() {
+
+        // Given
+        Supply supplyWithBlankCode = SupplyMother.random().withDistributorCode("   ").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supplyWithBlankCode));
+
+        // When
+        service.aggregateMonthlyConsumptions(Month.MARCH, 2024);
+
+        // Then
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+    }
+
+    @Test
+    void testAggregateMonthlyForSpecificSupplyWithoutDistributorCodeDoesNothing() {
+
+        // Given
+        Supply supply = SupplyMother.random().withDistributorCode(null).build();
+        SupplyCode supplyCode = SupplyCode.of(supply.getCode());
+        when(getSupplyRepository.findByCode(supplyCode)).thenReturn(Optional.of(supply));
+
+        // When
+        service.aggregateMonthlyConsumptions(supplyCode, Month.JUNE, 2024);
+
+        // Then - skipped because no distributor code
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+    }
+
+    @Test
+    void testAggregateMonthlyWithSupplyNotFound() {
+
+        // Given
+        SupplyCode unknownCode = SupplyCode.of("UNKNOWN_CUPS");
+        when(getSupplyRepository.findByCode(unknownCode)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(SupplyNotFoundException.class, () ->
+                service.aggregateMonthlyConsumptions(unknownCode, Month.JUNE, 2024));
+
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+    }
+
+    @Test
+    void testAggregateMonthlyHandlesRepositoryException() {
+
+        // Given
+        Supply supply = SupplyMother.random().withDistributorCode("DIST123").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supply));
+        doThrow(new RuntimeException("InfluxDB connection error"))
+                .when(aggregationRepository)
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+
+        // When - should not throw, just log error
+        service.aggregateMonthlyConsumptions(Month.JUNE, 2024);
+
+        // Then - attempted the call
+        verify(aggregationRepository, times(1))
+                .aggregateMonthlyConsumption(eq(supply), eq(Month.JUNE), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyWithEmptySupplyList() {
+
+        // Given
+        when(getSupplyRepository.findAll()).thenReturn(Collections.emptyList());
+
+        // When
+        service.aggregateMonthlyConsumptions(2024);
+
+        // Then
+        verify(aggregationRepository, never())
+                .aggregateMonthlyConsumption(any(Supply.class), any(Month.class), anyInt());
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationJobTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationJobTest.java
@@ -1,0 +1,29 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationService;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class DatadisYearlyAggregationJobTest {
+
+    @Test
+    void testRun_ShouldCallServiceWithPreviousYear() {
+        // Arrange
+        DatadisYearlyAggregationService mockService = Mockito.mock(DatadisYearlyAggregationService.class);
+        DatadisYearlyAggregationJob job = new DatadisYearlyAggregationJob(mockService);
+
+        LocalDate today = LocalDate.now();
+        int year = today.getYear();
+
+        // Act
+        job.run();
+
+        // Assert
+        verify(mockService, times(1)).aggregateYearlyConsumptions(year);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationRepositoryInfluxTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationRepositoryInfluxTest.java
@@ -1,0 +1,211 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.influxdb.impl.InfluxDBResultMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationRepository;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.DatadisConsumptionYearlyPoint;
+import org.lucoenergia.conluz.infrastructure.consumption.datadis.config.DatadisConfigEntity;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxDbConnectionManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for DatadisYearlyAggregationRepositoryInflux.
+ * <p>
+ * Test data: 12 monthly records for 2023.
+ * Expected sums after aggregation:
+ *   consumption_kwh:             4205.8
+ *   surplus_energy_kwh:           728.0
+ *   self_consumption_energy_kwh: 1518.0
+ * <p>
+ * The aggregated record timestamp is December 31, 2023 at midnight local time (Europe/Madrid, UTC+1),
+ * which is 2023-12-30T23:00:00Z in UTC.
+ */
+class DatadisYearlyAggregationRepositoryInfluxTest extends BaseIntegrationTest {
+
+    private static final String CUPS_CODE = "ES0031406912345678JN0F";
+
+    @Autowired
+    private DatadisYearlyAggregationRepository repository;
+
+    @Autowired
+    private InfluxDbConnectionManager influxDbConnectionManager;
+
+    private Supply supply;
+
+    @BeforeEach
+    void setUp() {
+        User user = UserMother.randomUser();
+        supply = SupplyMother.random(user).withCode(CUPS_CODE).build();
+        clearMonthlyMeasurementForCups();
+        loadMonthlyDataFor2023();
+    }
+
+    @AfterEach
+    void tearDown() {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            for (String measurement : List.of(
+                    DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT,
+                    DatadisConfigEntity.CONSUMPTION_KWH_YEAR_MEASUREMENT)) {
+                connection.query(new Query(String.format(
+                        "DROP SERIES FROM \"%s\" WHERE \"cups\" = '%s'",
+                        measurement, CUPS_CODE)));
+            }
+        }
+    }
+
+    @Test
+    void testAggregateYearlyConsumptionComputesCorrectSums() {
+
+        // When
+        repository.aggregateYearlyConsumption(supply, 2023);
+
+        // Then - query using a window wide enough to capture Dec 31 midnight in any timezone
+        // Dec 31, 2023 00:00:00 Europe/Madrid (UTC+1) = 2023-12-30T23:00:00Z
+        List<DatadisConsumptionYearlyPoint> result = queryYearlyData(
+                "2023-12-30T20:00:00Z", "2023-12-31T04:00:00Z");
+
+        assertFalse(result.isEmpty(), "Expected aggregated yearly data to be written for 2023");
+        assertEquals(1, result.size());
+
+        DatadisConsumptionYearlyPoint point = result.get(0);
+        assertEquals(CUPS_CODE, point.getCups());
+
+        // Sum of all 12 monthly consumption values = 4205.8
+        assertNotNull(point.getConsumptionKWh());
+        assertEquals(4205.8, point.getConsumptionKWh(), 0.1,
+                "Total consumption should be the sum of all monthly records for 2023");
+
+        // Sum of all 12 monthly surplus values = 728.0
+        assertNotNull(point.getSurplusEnergyKWh());
+        assertEquals(728.0, point.getSurplusEnergyKWh(), 0.1,
+                "Total surplus should be the sum of all monthly surplus values for 2023");
+
+        // Sum of all 12 monthly self-consumption values = 1518.0
+        assertNotNull(point.getSelfConsumptionEnergyKWh());
+        assertEquals(1518.0, point.getSelfConsumptionEnergyKWh(), 0.1,
+                "Total self-consumption should be the sum of all monthly self-consumption values for 2023");
+
+        assertNotNull(point.getObtainMethod());
+        assertEquals("Real", point.getObtainMethod());
+    }
+
+    @Test
+    void testAggregateYearlyConsumptionSetsTimestampToDecember31st() {
+
+        // When
+        repository.aggregateYearlyConsumption(supply, 2023);
+
+        // Then - the aggregated point must exist at December 31 midnight (local timezone)
+        // Dec 31, 2023 00:00:00 Europe/Madrid (UTC+1) = 2023-12-30T23:00:00Z
+        List<DatadisConsumptionYearlyPoint> inWindow = queryYearlyData(
+                "2023-12-30T20:00:00Z", "2023-12-31T04:00:00Z");
+
+        assertFalse(inWindow.isEmpty(),
+                "Aggregated point should be stored at December 31st at midnight (local time)");
+
+        // Verify it does NOT appear earlier in the year
+        List<DatadisConsumptionYearlyPoint> beforeDecember = queryYearlyData(
+                "2023-01-01T00:00:00Z", "2023-12-30T19:59:59Z");
+
+        assertTrue(beforeDecember.isEmpty(),
+                "Aggregated point must not appear before December 31st");
+    }
+
+    @Test
+    void testAggregateYearlyConsumptionWithNoMonthlyDataDoesNotWrite() {
+
+        // When - aggregate for 2022, which has no monthly data loaded
+        repository.aggregateYearlyConsumption(supply, 2022);
+
+        // Then - nothing should be written to the yearly measurement for 2022
+        List<DatadisConsumptionYearlyPoint> result = queryYearlyData(
+                "2022-12-30T20:00:00Z", "2022-12-31T04:00:00Z");
+
+        assertTrue(result.isEmpty(),
+                "No yearly data should be written when there is no monthly source data");
+    }
+
+    // -----------------------------------------------------------------------
+    // Data setup helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Removes all monthly series for the test CUPS code to prevent data pollution
+     * from other tests that may write to the same measurement.
+     */
+    private void clearMonthlyMeasurementForCups() {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            connection.query(new Query(String.format(
+                    "DROP SERIES FROM \"%s\" WHERE \"cups\" = '%s'",
+                    DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT, CUPS_CODE)));
+        }
+    }
+
+    /**
+     * Loads 12 monthly records for 2023 (same data as DatadisConsumptionInfluxLoader).
+     * Sums: consumption=4205.8, surplus=728.0, self_consumption=1518.0
+     */
+    private void loadMonthlyDataFor2023() {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            BatchPoints batchPoints = influxDbConnectionManager.createBatchPoints();
+
+            // Each timestamp is the 1st of the month at 00:00:00 UTC (nanoseconds)
+            loadMonthlyPoint(batchPoints, 1672531200000000000L, 450.5, 25.0,  85.0);  // Jan 2023
+            loadMonthlyPoint(batchPoints, 1675209600000000000L, 420.3, 30.0,  90.0);  // Feb 2023
+            loadMonthlyPoint(batchPoints, 1677628800000000000L, 380.7, 45.0, 110.0);  // Mar 2023
+            loadMonthlyPoint(batchPoints, 1680307200000000000L, 330.2, 65.0, 135.0);  // Apr 2023
+            loadMonthlyPoint(batchPoints, 1682899200000000000L, 290.8, 85.0, 155.0);  // May 2023
+            loadMonthlyPoint(batchPoints, 1685577600000000000L, 270.5, 95.0, 165.0);  // Jun 2023
+            loadMonthlyPoint(batchPoints, 1688169600000000000L, 285.3, 98.0, 168.0);  // Jul 2023
+            loadMonthlyPoint(batchPoints, 1690848000000000000L, 295.6, 92.0, 162.0);  // Aug 2023
+            loadMonthlyPoint(batchPoints, 1693526400000000000L, 310.4, 75.0, 145.0);  // Sep 2023
+            loadMonthlyPoint(batchPoints, 1696118400000000000L, 340.8, 55.0, 120.0);  // Oct 2023
+            loadMonthlyPoint(batchPoints, 1698796800000000000L, 390.5, 35.0,  95.0);  // Nov 2023
+            loadMonthlyPoint(batchPoints, 1701388800000000000L, 440.2, 28.0,  88.0);  // Dec 2023
+
+            connection.write(batchPoints);
+        }
+    }
+
+    private void loadMonthlyPoint(BatchPoints batchPoints, long timestampNanos,
+                                   double consumption, double surplus, double selfConsumption) {
+        batchPoints.point(Point.measurement(DatadisConfigEntity.CONSUMPTION_KWH_MONTH_MEASUREMENT)
+                .time(timestampNanos, TimeUnit.NANOSECONDS)
+                .tag("cups", CUPS_CODE)
+                .addField("consumption_kwh", consumption)
+                .addField("surplus_energy_kwh", surplus)
+                .addField("self_consumption_energy_kwh", selfConsumption)
+                .addField("generation_energy_kwh", 0.0)
+                .addField("obtain_method", "Real")
+                .build());
+    }
+
+    private List<DatadisConsumptionYearlyPoint> queryYearlyData(String startDate, String endDate) {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            Query query = new Query(String.format(
+                    "SELECT * FROM \"%s\" WHERE cups = '%s' AND time >= '%s' AND time <= '%s'",
+                    DatadisConfigEntity.CONSUMPTION_KWH_YEAR_MEASUREMENT, CUPS_CODE, startDate, endDate));
+            QueryResult result = connection.query(query);
+            InfluxDBResultMapper mapper = new InfluxDBResultMapper();
+            return mapper.toPOJO(result, DatadisConsumptionYearlyPoint.class);
+        }
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/aggregate/DatadisYearlyAggregationServiceImplTest.java
@@ -1,0 +1,153 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.aggregate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DatadisYearlyAggregationServiceImplTest {
+
+    @Mock
+    private GetSupplyRepository getSupplyRepository;
+
+    @Mock
+    private DatadisYearlyAggregationRepository aggregationRepository;
+
+    @InjectMocks
+    private DatadisYearlyAggregationServiceImpl service;
+
+    @Test
+    void testAggregateYearlyForAllSupplies() {
+
+        // Given
+        Supply supply1 = SupplyMother.random().withDistributorCode("DIST001").build();
+        Supply supply2 = SupplyMother.random().withDistributorCode("DIST002").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supply1, supply2));
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - one call per supply
+        verify(aggregationRepository, times(1)).aggregateYearlyConsumption(eq(supply1), eq(2024));
+        verify(aggregationRepository, times(1)).aggregateYearlyConsumption(eq(supply2), eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlyForSpecificSupply() {
+
+        // Given
+        Supply supply = SupplyMother.random().withDistributorCode("DIST123").build();
+        SupplyCode supplyCode = SupplyCode.of(supply.getCode());
+        when(getSupplyRepository.findByCode(supplyCode)).thenReturn(Optional.of(supply));
+
+        // When
+        service.aggregateYearlyConsumptions(supplyCode, 2024);
+
+        // Then
+        verify(aggregationRepository, times(1)).aggregateYearlyConsumption(eq(supply), eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlySkipsSuppliesWithoutDistributorCode() {
+
+        // Given
+        Supply supplyWithCode = SupplyMother.random().withDistributorCode("DIST001").build();
+        Supply supplyWithoutCode = SupplyMother.random().withDistributorCode(null).build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supplyWithCode, supplyWithoutCode));
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - only supply with distributor code is processed
+        verify(aggregationRepository, times(1)).aggregateYearlyConsumption(eq(supplyWithCode), eq(2024));
+        verify(aggregationRepository, never()).aggregateYearlyConsumption(eq(supplyWithoutCode), anyInt());
+    }
+
+    @Test
+    void testAggregateYearlySkipsSuppliesWithBlankDistributorCode() {
+
+        // Given
+        Supply supplyWithBlankCode = SupplyMother.random().withDistributorCode("   ").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supplyWithBlankCode));
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then
+        verify(aggregationRepository, never()).aggregateYearlyConsumption(any(Supply.class), anyInt());
+    }
+
+    @Test
+    void testAggregateYearlyForSpecificSupplyWithoutDistributorCodeDoesNothing() {
+
+        // Given
+        Supply supply = SupplyMother.random().withDistributorCode(null).build();
+        SupplyCode supplyCode = SupplyCode.of(supply.getCode());
+        when(getSupplyRepository.findByCode(supplyCode)).thenReturn(Optional.of(supply));
+
+        // When
+        service.aggregateYearlyConsumptions(supplyCode, 2024);
+
+        // Then - skipped because no distributor code
+        verify(aggregationRepository, never()).aggregateYearlyConsumption(any(Supply.class), anyInt());
+    }
+
+    @Test
+    void testAggregateYearlyWithSupplyNotFound() {
+
+        // Given
+        SupplyCode unknownCode = SupplyCode.of("UNKNOWN_CUPS");
+        when(getSupplyRepository.findByCode(unknownCode)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(SupplyNotFoundException.class, () ->
+                service.aggregateYearlyConsumptions(unknownCode, 2024));
+
+        verify(aggregationRepository, never()).aggregateYearlyConsumption(any(Supply.class), anyInt());
+    }
+
+    @Test
+    void testAggregateYearlyHandlesRepositoryException() {
+
+        // Given
+        Supply supply = SupplyMother.random().withDistributorCode("DIST123").build();
+        when(getSupplyRepository.findAll()).thenReturn(List.of(supply));
+        doThrow(new RuntimeException("InfluxDB connection error"))
+                .when(aggregationRepository)
+                .aggregateYearlyConsumption(any(Supply.class), anyInt());
+
+        // When - should not throw, just log error
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then - attempted the call
+        verify(aggregationRepository, times(1)).aggregateYearlyConsumption(eq(supply), eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlyWithEmptySupplyList() {
+
+        // Given
+        when(getSupplyRepository.findAll()).thenReturn(Collections.emptyList());
+
+        // When
+        service.aggregateYearlyConsumptions(2024);
+
+        // Then
+        verify(aggregationRepository, never()).aggregateYearlyConsumption(any(Supply.class), anyInt());
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncMonthlyDatadisConsumptionsControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncMonthlyDatadisConsumptionsControllerTest.java
@@ -1,0 +1,236 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.sync;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisMonthlyAggregationService;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Month;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SyncMonthlyDatadisConsumptionsControllerTest extends BaseControllerTest {
+
+    private static final String URL = "/api/v1/consumption/datadis/sync/monthly";
+
+    @MockitoBean
+    private DatadisMonthlyAggregationService aggregationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testAggregateMonthlyForAllSuppliesAllMonths() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(aggregationService, times(1))
+                .aggregateMonthlyConsumptions(eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForAllSuppliesSpecificMonth() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024, 1);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(aggregationService, times(1))
+                .aggregateMonthlyConsumptions(eq(Month.JANUARY), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForSpecificSupplyAllMonths() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024, null, "SUPPLY001");
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // Should call for all 12 months
+        verify(aggregationService, times(12))
+                .aggregateMonthlyConsumptions(any(SupplyCode.class), any(Month.class), eq(2024));
+    }
+
+    @Test
+    void testAggregateMonthlyForSpecificSupplySpecificMonth() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024, 6, "SUPPLY001");
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(aggregationService, times(1))
+                .aggregateMonthlyConsumptions(eq(SupplyCode.of("SUPPLY001")), eq(Month.JUNE), eq(2024));
+    }
+
+    @Test
+    void testWithoutToken() throws Exception {
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024);
+
+        mockMvc.perform(post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    void testAuthenticatedUserWithoutAdminRoleCannotAccess() throws Exception {
+
+        String authHeader = loginAsPartner();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    void testWithInvalidYearTooLow() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(1999);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithInvalidYearTooHigh() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2101);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithNullYear() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        String jsonBody = "{\"year\": null}";
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithInvalidMonthTooLow() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        String jsonBody = "{\"year\": 2024, \"month\": 0}";
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithInvalidMonthTooHigh() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        String jsonBody = "{\"year\": 2024, \"month\": 13}";
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithInvalidSupplyCode() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncMonthlyDatadisConsumptionsBody body = new SyncMonthlyDatadisConsumptionsBody(2024, 1, "INVALID");
+
+        doThrow(new SupplyNotFoundException(SupplyCode.of("INVALID")))
+                .when(aggregationService)
+                .aggregateMonthlyConsumptions(any(SupplyCode.class), any(Month.class), any(Integer.class));
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncYearlyDatadisConsumptionsControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/sync/SyncYearlyDatadisConsumptionsControllerTest.java
@@ -1,0 +1,165 @@
+package org.lucoenergia.conluz.infrastructure.consumption.datadis.sync;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
+import org.lucoenergia.conluz.domain.consumption.datadis.aggregate.DatadisYearlyAggregationService;
+import org.lucoenergia.conluz.domain.shared.SupplyCode;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SyncYearlyDatadisConsumptionsControllerTest extends BaseControllerTest {
+
+    private static final String URL = "/api/v1/consumption/datadis/sync/yearly";
+
+    @MockitoBean
+    private DatadisYearlyAggregationService aggregationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testAggregateYearlyForAllSupplies() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(2024);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(aggregationService, times(1))
+                .aggregateYearlyConsumptions(eq(2024));
+    }
+
+    @Test
+    void testAggregateYearlyForSpecificSupply() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(2024, "SUPPLY001");
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(aggregationService, times(1))
+                .aggregateYearlyConsumptions(eq(SupplyCode.of("SUPPLY001")), eq(2024));
+    }
+
+    @Test
+    void testWithoutToken() throws Exception {
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(2024);
+
+        mockMvc.perform(post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    void testAuthenticatedUserWithoutAdminRoleCannotAccess() throws Exception {
+
+        String authHeader = loginAsPartner();
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(2024);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    void testWithInvalidYearTooLow() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(1999);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithInvalidYearTooHigh() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(2101);
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithNullYear() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        String jsonBody = "{\"year\": null}";
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void testWithInvalidSupplyCode() throws Exception {
+
+        String authHeader = loginAsDefaultAdmin();
+
+        SyncYearlyDatadisConsumptionsBody body = new SyncYearlyDatadisConsumptionsBody(2024, "INVALID");
+
+        doThrow(new SupplyNotFoundException(SupplyCode.of("INVALID")))
+                .when(aggregationService)
+                .aggregateYearlyConsumptions(any(SupplyCode.class), any(Integer.class));
+
+        mockMvc.perform(post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+    }
+}


### PR DESCRIPTION
The problem being solved                                                                                                                                                     
                                                                                                                                                                               
  Previously, when the system synced hourly consumption data from Datadis, it would also immediately compute and store the monthly and yearly aggregations for that data as    
  part of the same operation. This meant aggregations were always tied to the sync process — you couldn't recompute them independently.
                                                                                                                                                                               
  New behaviour                                                                                                                                                                
                                                                                                                                                                               
  Monthly and yearly aggregated consumption data is now computed separately from the raw hourly sync:                                                                          
                                                                                                                                                                               
  - Automatic daily recalculation: Every day at 5:00 AM the system recalculates monthly consumption aggregates, and at 6:00 AM it recalculates yearly aggregates. Both are     
  derived from the hourly data already stored.                                                                                                                                 
  - Manual on-demand recalculation: Admins can now trigger a recalculation at any time via two new API endpoints:
    - POST /api/v1/consumption/datadis/sync/monthly — recalculates monthly aggregates for a given year, optionally filtered by month and/or supply point.
    - POST /api/v1/consumption/datadis/sync/yearly — recalculates yearly aggregates for a given year, optionally filtered by supply point.

  In practice

  This means that if historical hourly data is corrected or re-synced, the monthly and yearly figures can be recomputed independently without having to re-run the full Datadis
   sync. It also gives admins explicit control over when and for which scope aggregations are refreshed.