### PR TITLE
[conluz-165] Phase 2 multi-community: access guard, community contextfilter, and JWT membership claims

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/admin/community/access/CommunityAccessGuard.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/community/access/CommunityAccessGuard.java
@@ -1,0 +1,18 @@
+package org.lucoenergia.conluz.domain.admin.community.access;
+
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+
+import java.util.UUID;
+
+public interface CommunityAccessGuard {
+
+    boolean canReadSupply(Supply supply);
+
+    boolean canEditSupply(Supply supply);
+
+    boolean canReadCommunity(UUID communityId);
+
+    boolean canManageCommunity(UUID communityId);
+
+    boolean canManagePlatform();
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/user/User.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/user/User.java
@@ -4,11 +4,14 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMembership;
+import org.lucoenergia.conluz.domain.admin.community.CommunityRole;
 import org.lucoenergia.conluz.infrastructure.shared.uuid.ValidUUID;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -39,6 +42,7 @@ public class User implements UserDetails {
     @NotNull
     private Role role;
     private Boolean isPlatformAdmin;
+    private List<CommunityMembership> memberships = new ArrayList<>();
 
     public UUID getId() {
         return id;
@@ -128,9 +132,27 @@ public class User implements UserDetails {
         this.isPlatformAdmin = isPlatformAdmin;
     }
 
+    public List<CommunityMembership> getMemberships() {
+        return memberships;
+    }
+
+    public void setMemberships(List<CommunityMembership> memberships) {
+        this.memberships = memberships;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + role.name()));
+        if (Boolean.TRUE.equals(isPlatformAdmin)) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_PLATFORM_ADMIN"));
+        }
+        boolean isCommunityAdmin = memberships != null && memberships.stream()
+                .anyMatch(m -> m.getRole() == CommunityRole.COMMUNITY_ADMIN && Boolean.TRUE.equals(m.isEnabled()));
+        if (isCommunityAdmin) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_COMMUNITY_ADMIN"));
+        }
+        return authorities;
     }
 
     @Override

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/user/auth/AuthRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/user/auth/AuthRepository.java
@@ -3,6 +3,7 @@ package org.lucoenergia.conluz.domain.admin.user.auth;
 import org.lucoenergia.conluz.domain.admin.user.User;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,4 +26,20 @@ public interface AuthRepository {
      * @return The JWT ID, or empty if not present or if an error occurs
      */
     Optional<String> getJtiFromToken(Token token);
+
+    /**
+     * Returns whether the token owner is a platform admin.
+     *
+     * @param token The token
+     * @return true if the token was issued for a platform admin
+     */
+    boolean isPlatformAdmin(Token token);
+
+    /**
+     * Returns the community memberships encoded in the token.
+     *
+     * @param token The token
+     * @return A map of community id (string) to role name (string)
+     */
+    Map<String, String> getCommunityMemberships(Token token);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/CommunityMembershipJpaRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/CommunityMembershipJpaRepository.java
@@ -2,7 +2,10 @@ package org.lucoenergia.conluz.infrastructure.admin.community;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface CommunityMembershipJpaRepository extends JpaRepository<CommunityMembershipEntity, UUID> {
+
+    List<CommunityMembershipEntity> findByUser_Id(UUID userId);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/CommunityMembershipJpaRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/CommunityMembershipJpaRepository.java
@@ -7,5 +7,5 @@ import java.util.UUID;
 
 public interface CommunityMembershipJpaRepository extends JpaRepository<CommunityMembershipEntity, UUID> {
 
-    List<CommunityMembershipEntity> findByUser_Id(UUID userId);
+    List<CommunityMembershipEntity> findByUserId(UUID userId);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/access/CommunityAccessGuardImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/access/CommunityAccessGuardImpl.java
@@ -1,0 +1,84 @@
+package org.lucoenergia.conluz.infrastructure.admin.community.access;
+
+import org.lucoenergia.conluz.domain.admin.community.CommunityRole;
+import org.lucoenergia.conluz.domain.admin.community.access.CommunityAccessGuard;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.user.Role;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.auth.AuthService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service("communityAccessGuard")
+@Transactional(readOnly = true)
+public class CommunityAccessGuardImpl implements CommunityAccessGuard {
+
+    private final AuthService authService;
+
+    public CommunityAccessGuardImpl(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean canReadSupply(Supply supply) {
+        User user = authService.getCurrentUser().orElse(null);
+        if (user == null) return false;
+        if (user.getRole() == Role.ADMIN) return true;
+        if (isOwner(supply, user)) return true;
+        return hasMembershipInCommunity(user, supply.getCommunity() != null ? supply.getCommunity().getId() : null);
+    }
+
+    @Override
+    public boolean canEditSupply(Supply supply) {
+        User user = authService.getCurrentUser().orElse(null);
+        if (user == null) return false;
+        if (user.getRole() == Role.ADMIN) return true;
+        if (isOwner(supply, user)) return true;
+        return hasCommunityAdminRoleIn(user, supply.getCommunity() != null ? supply.getCommunity().getId() : null);
+    }
+
+    @Override
+    public boolean canReadCommunity(UUID communityId) {
+        User user = authService.getCurrentUser().orElse(null);
+        if (user == null) return false;
+        if (user.getRole() == Role.ADMIN) return true;
+        return hasMembershipInCommunity(user, communityId);
+    }
+
+    @Override
+    public boolean canManageCommunity(UUID communityId) {
+        User user = authService.getCurrentUser().orElse(null);
+        if (user == null) return false;
+        if (user.getRole() == Role.ADMIN) return true;
+        return hasCommunityAdminRoleIn(user, communityId);
+    }
+
+    @Override
+    public boolean canManagePlatform() {
+        return authService.getCurrentUser()
+                .map(User::isPlatformAdmin)
+                .orElse(false);
+    }
+
+    private boolean isOwner(Supply supply, User user) {
+        return supply.getUser() != null && supply.getUser().getId() != null
+                && supply.getUser().getId().equals(user.getId());
+    }
+
+    private boolean hasMembershipInCommunity(User user, UUID communityId) {
+        if (communityId == null || user.getMemberships() == null) return false;
+        return user.getMemberships().stream()
+                .anyMatch(m -> communityId.equals(m.getCommunity().getId())
+                        && Boolean.TRUE.equals(m.isEnabled()));
+    }
+
+    private boolean hasCommunityAdminRoleIn(User user, UUID communityId) {
+        if (communityId == null || user.getMemberships() == null) return false;
+        return user.getMemberships().stream()
+                .anyMatch(m -> communityId.equals(m.getCommunity().getId())
+                        && m.getRole() == CommunityRole.COMMUNITY_ADMIN
+                        && Boolean.TRUE.equals(m.isEnabled()));
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyRepository.java
@@ -1,12 +1,13 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface SupplyRepository extends JpaRepository<SupplyEntity, UUID> {
+public interface SupplyRepository extends JpaRepository<SupplyEntity, UUID>, JpaSpecificationExecutor<SupplyEntity> {
 
     Optional<SupplyEntity> findByCode(String code);
 

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplySpecifications.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplySpecifications.java
@@ -1,0 +1,36 @@
+package org.lucoenergia.conluz.infrastructure.admin.supply;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * JPA Specification helpers for community-scoped supply queries.
+ *
+ * CONVENTION: All new user-facing supply queries MUST use visibleToCommunities() to prevent
+ * cross-community data leaks. The acrossAllCommunities() escape hatch is reserved for
+ * system-level operations (batch jobs, admin maintenance). Every call site using
+ * acrossAllCommunities() MUST include a comment explaining why it is cross-community.
+ */
+public class SupplySpecifications {
+
+    private SupplySpecifications() {}
+
+    public static Specification<SupplyEntity> visibleToCommunities(Set<UUID> communityIds) {
+        return (root, query, cb) -> {
+            if (communityIds == null || communityIds.isEmpty()) {
+                return cb.disjunction();
+            }
+            return root.get("community").get("id").in(communityIds);
+        };
+    }
+
+    /**
+     * Escape hatch — for batch jobs and admin maintenance that legitimately cross community boundaries.
+     * Call sites MUST include a code comment justifying cross-community access.
+     */
+    public static Specification<SupplyEntity> acrossAllCommunities() {
+        return (root, query, cb) -> cb.conjunction();
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyServiceImpl.java
@@ -1,5 +1,6 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply.get;
 
+import org.lucoenergia.conluz.domain.admin.community.access.CommunityAccessGuard;
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
@@ -16,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Transactional(readOnly = true)
 @Service
@@ -24,10 +24,13 @@ public class GetSupplyServiceImpl implements GetSupplyService {
 
     private final GetSupplyRepository repository;
     private final AuthService authService;
+    private final CommunityAccessGuard communityAccessGuard;
 
-    public GetSupplyServiceImpl(GetSupplyRepository repository, AuthService authService) {
+    public GetSupplyServiceImpl(GetSupplyRepository repository, AuthService authService,
+                                CommunityAccessGuard communityAccessGuard) {
         this.repository = repository;
         this.authService = authService;
+        this.communityAccessGuard = communityAccessGuard;
     }
 
     public PagedResult<Supply> findAll(PagedRequest pagedRequest) {
@@ -38,21 +41,11 @@ public class GetSupplyServiceImpl implements GetSupplyService {
     public Supply getById(SupplyId id) {
         Supply supply = repository.findById(id).orElseThrow(() -> new SupplyNotFoundException(id));
 
-        Optional<User> user = authService.getCurrentUser();
-        if (user.isEmpty()) {
+        if (!communityAccessGuard.canReadSupply(supply)) {
             throw new AccessDeniedException("You do not have permission to access this supply");
         }
 
-        // If user is ADMIN, return always
-        if (user.get().getRole() == Role.ADMIN) {
-            return supply;
-        }
-        // Otherwise, only if the supply belongs to the authenticated user
-        if (supply.getUser() != null && supply.getUser().getId() != null && supply.getUser().getId().equals(user.get().getId())) {
-            return supply;
-        }
-
-        throw new AccessDeniedException("You do not have permission to access this supply");
+        return supply;
     }
 
     @Override

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/package-info.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Supply filtering convention: all user-facing queries must use SupplySpecifications.visibleToCommunities().
+ * Cross-community queries (batch jobs, migrations) must use SupplySpecifications.acrossAllCommunities()
+ * with a justification comment at the call site.
+ */
+package org.lucoenergia.conluz.infrastructure.admin.supply;

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/auth/UserDetailsServiceFromDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/auth/UserDetailsServiceFromDatabase.java
@@ -1,5 +1,10 @@
 package org.lucoenergia.conluz.infrastructure.admin.user.auth;
 
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMembership;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityMembershipEntity;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityMembershipJpaRepository;
 import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
 import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
 import org.lucoenergia.conluz.infrastructure.shared.uuid.UUIDValidator;
@@ -7,15 +12,19 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public class UserDetailsServiceFromDatabase implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final CommunityMembershipJpaRepository communityMembershipJpaRepository;
 
-    public UserDetailsServiceFromDatabase(UserRepository userRepository) {
+    public UserDetailsServiceFromDatabase(UserRepository userRepository,
+                                          CommunityMembershipJpaRepository communityMembershipJpaRepository) {
         this.userRepository = userRepository;
+        this.communityMembershipJpaRepository = communityMembershipJpaRepository;
     }
 
     @Override
@@ -30,6 +39,35 @@ public class UserDetailsServiceFromDatabase implements UserDetailsService {
         if (userEntity.isEmpty()) {
             throw new UsernameNotFoundException(userId);
         }
-        return userEntity.get().getUser();
+        User user = userEntity.get().getUser();
+
+        // Load community memberships for the user
+        List<CommunityMembershipEntity> membershipEntities =
+                communityMembershipJpaRepository.findByUser_Id(user.getId());
+        List<CommunityMembership> memberships = membershipEntities.stream()
+                .map(this::mapMembership)
+                .toList();
+        user.setMemberships(memberships);
+
+        return user;
+    }
+
+    private CommunityMembership mapMembership(CommunityMembershipEntity entity) {
+        Community community = new Community.Builder()
+                .withId(entity.getCommunity().getId())
+                .withName(entity.getCommunity().getName())
+                .withCode(entity.getCommunity().getCode())
+                .withEnabled(entity.getCommunity().isEnabled())
+                .build();
+        // Only id is needed for the membership user reference to avoid circular loading
+        User membershipUser = new User();
+        membershipUser.setId(entity.getUser().getId());
+        return new CommunityMembership.Builder()
+                .withId(entity.getId())
+                .withUser(membershipUser)
+                .withCommunity(community)
+                .withRole(entity.getRole())
+                .withEnabled(entity.isEnabled())
+                .build();
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/auth/UserDetailsServiceFromDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/auth/UserDetailsServiceFromDatabase.java
@@ -43,7 +43,7 @@ public class UserDetailsServiceFromDatabase implements UserDetailsService {
 
         // Load community memberships for the user
         List<CommunityMembershipEntity> membershipEntities =
-                communityMembershipJpaRepository.findByUser_Id(user.getId());
+                communityMembershipJpaRepository.findByUserId(user.getId());
         List<CommunityMembership> memberships = membershipEntities.stream()
                 .map(this::mapMembership)
                 .toList();

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/get/GetDatadisConsumptionServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/consumption/datadis/get/GetDatadisConsumptionServiceImpl.java
@@ -1,11 +1,9 @@
 package org.lucoenergia.conluz.infrastructure.consumption.datadis.get;
 
+import org.lucoenergia.conluz.domain.admin.community.access.CommunityAccessGuard;
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
-import org.lucoenergia.conluz.domain.admin.user.Role;
-import org.lucoenergia.conluz.domain.admin.user.User;
-import org.lucoenergia.conluz.domain.admin.user.auth.AuthService;
 import org.lucoenergia.conluz.domain.consumption.datadis.DatadisConsumption;
 import org.lucoenergia.conluz.domain.consumption.datadis.get.GetDatadisConsumptionRepository;
 import org.lucoenergia.conluz.domain.consumption.datadis.get.GetDatadisConsumptionService;
@@ -25,122 +23,70 @@ public class GetDatadisConsumptionServiceImpl implements GetDatadisConsumptionSe
 
     private final GetDatadisConsumptionRepository getDatadisConsumptionRepository;
     private final GetSupplyRepository getSupplyRepository;
-    private final AuthService authService;
+    private final CommunityAccessGuard communityAccessGuard;
 
     public GetDatadisConsumptionServiceImpl(
             @Qualifier("getDatadisConsumptionRepositoryInflux") GetDatadisConsumptionRepository getDatadisConsumptionRepository,
             GetSupplyRepository getSupplyRepository,
-            AuthService authService) {
+            CommunityAccessGuard communityAccessGuard) {
         this.getDatadisConsumptionRepository = getDatadisConsumptionRepository;
         this.getSupplyRepository = getSupplyRepository;
-        this.authService = authService;
+        this.communityAccessGuard = communityAccessGuard;
     }
 
     @Override
     public List<DatadisConsumption> getDailyConsumptionBySupply(SupplyId supplyId, OffsetDateTime startDate,
                                                                 OffsetDateTime endDate) {
-        // Get current authenticated user
-        User currentUser = authService.getCurrentUser()
-                .orElseThrow(() -> new IllegalStateException("User must be authenticated"));
+        Supply supply = getSupplyOrThrow(supplyId);
 
-        // Get the supply
-        Optional<Supply> supplyOptional = getSupplyRepository.findById(supplyId);
-        if (supplyOptional.isEmpty()) {
-            throw new SupplyNotFoundException(supplyId);
-        }
-
-        Supply supply = supplyOptional.get();
-
-        // Authorization: ADMIN can access any supply, non-ADMIN can only access their own supplies
-        boolean isAdmin = currentUser.getRole() == Role.ADMIN;
-        boolean isOwner = supply.getUser().getId().equals(currentUser.getId());
-
-        if (!isAdmin && !isOwner) {
+        if (!communityAccessGuard.canReadSupply(supply)) {
             throw new AccessDeniedException("User does not have permission to access this supply's consumption data");
         }
 
-        // Retrieve consumption data
         return getDatadisConsumptionRepository.getDailyConsumptionsByRangeOfDates(supply, startDate, endDate);
     }
 
     @Override
     public List<DatadisConsumption> getHourlyConsumptionBySupply(SupplyId supplyId, OffsetDateTime startDate,
                                                                  OffsetDateTime endDate) {
-        // Get current authenticated user
-        User currentUser = authService.getCurrentUser()
-                .orElseThrow(() -> new IllegalStateException("User must be authenticated"));
+        Supply supply = getSupplyOrThrow(supplyId);
 
-        // Get the supply
-        Optional<Supply> supplyOptional = getSupplyRepository.findById(supplyId);
-        if (supplyOptional.isEmpty()) {
-            throw new SupplyNotFoundException(supplyId);
-        }
-
-        Supply supply = supplyOptional.get();
-
-        // Authorization: ADMIN can access any supply, non-ADMIN can only access their own supplies
-        boolean isAdmin = currentUser.getRole() == Role.ADMIN;
-        boolean isOwner = supply.getUser().getId().equals(currentUser.getId());
-
-        if (!isAdmin && !isOwner) {
+        if (!communityAccessGuard.canReadSupply(supply)) {
             throw new AccessDeniedException("User does not have permission to access this supply's consumption data");
         }
 
-        // Retrieve consumption data
         return getDatadisConsumptionRepository.getHourlyConsumptionsByRangeOfDates(supply, startDate, endDate);
     }
 
     @Override
     public List<DatadisConsumption> getMonthlyConsumptionBySupply(SupplyId supplyId, OffsetDateTime startDate,
                                                                    OffsetDateTime endDate) {
-        // Get current authenticated user
-        User currentUser = authService.getCurrentUser()
-                .orElseThrow(() -> new IllegalStateException("User must be authenticated"));
+        Supply supply = getSupplyOrThrow(supplyId);
 
-        // Get the supply
-        Optional<Supply> supplyOptional = getSupplyRepository.findById(supplyId);
-        if (supplyOptional.isEmpty()) {
-            throw new SupplyNotFoundException(supplyId);
-        }
-
-        Supply supply = supplyOptional.get();
-
-        // Authorization: ADMIN can access any supply, non-ADMIN can only access their own supplies
-        boolean isAdmin = currentUser.getRole() == Role.ADMIN;
-        boolean isOwner = supply.getUser().getId().equals(currentUser.getId());
-
-        if (!isAdmin && !isOwner) {
+        if (!communityAccessGuard.canReadSupply(supply)) {
             throw new AccessDeniedException("User does not have permission to access this supply's consumption data");
         }
 
-        // Retrieve consumption data
         return getDatadisConsumptionRepository.getMonthlyConsumptionsByRangeOfDates(supply, startDate, endDate);
     }
 
     @Override
     public List<DatadisConsumption> getYearlyConsumptionBySupply(SupplyId supplyId, OffsetDateTime startDate,
                                                                   OffsetDateTime endDate) {
-        // Get current authenticated user
-        User currentUser = authService.getCurrentUser()
-                .orElseThrow(() -> new IllegalStateException("User must be authenticated"));
+        Supply supply = getSupplyOrThrow(supplyId);
 
-        // Get the supply
+        if (!communityAccessGuard.canReadSupply(supply)) {
+            throw new AccessDeniedException("User does not have permission to access this supply's consumption data");
+        }
+
+        return getDatadisConsumptionRepository.getYearlyConsumptionsByRangeOfDates(supply, startDate, endDate);
+    }
+
+    private Supply getSupplyOrThrow(SupplyId supplyId) {
         Optional<Supply> supplyOptional = getSupplyRepository.findById(supplyId);
         if (supplyOptional.isEmpty()) {
             throw new SupplyNotFoundException(supplyId);
         }
-
-        Supply supply = supplyOptional.get();
-
-        // Authorization: ADMIN can access any supply, non-ADMIN can only access their own supplies
-        boolean isAdmin = currentUser.getRole() == Role.ADMIN;
-        boolean isOwner = supply.getUser().getId().equals(currentUser.getId());
-
-        if (!isAdmin && !isOwner) {
-            throw new AccessDeniedException("User does not have permission to access this supply's consumption data");
-        }
-
-        // Retrieve consumption data
-        return getDatadisConsumptionRepository.getYearlyConsumptionsByRangeOfDates(supply, startDate, endDate);
+        return supplyOptional.get();
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/ApplicationConfig.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/ApplicationConfig.java
@@ -1,5 +1,6 @@
 package org.lucoenergia.conluz.infrastructure.shared.security;
 
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityMembershipJpaRepository;
 import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
 import org.lucoenergia.conluz.infrastructure.admin.user.auth.UserDetailsServiceFromDatabase;
 import org.springframework.context.annotation.Bean;
@@ -16,9 +17,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class ApplicationConfig {
 
     private final UserRepository userRepository;
+    private final CommunityMembershipJpaRepository communityMembershipJpaRepository;
 
-    public ApplicationConfig(UserRepository userRepository) {
+    public ApplicationConfig(UserRepository userRepository,
+                             CommunityMembershipJpaRepository communityMembershipJpaRepository) {
         this.userRepository = userRepository;
+        this.communityMembershipJpaRepository = communityMembershipJpaRepository;
     }
 
     @Bean
@@ -41,6 +45,6 @@ public class ApplicationConfig {
 
     @Bean
     public UserDetailsService userDetailsService() {
-        return new UserDetailsServiceFromDatabase(userRepository);
+        return new UserDetailsServiceFromDatabase(userRepository, communityMembershipJpaRepository);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/WebSecurityConfig.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import org.lucoenergia.conluz.infrastructure.shared.error.ErrorBuilder;
 import org.lucoenergia.conluz.infrastructure.shared.error.GlobalExceptionFilter;
 import org.lucoenergia.conluz.infrastructure.shared.security.auth.JwtAuthenticationExceptionFilter;
 import org.lucoenergia.conluz.infrastructure.shared.security.auth.JwtAuthenticationFilter;
+import org.lucoenergia.conluz.infrastructure.shared.security.community.CommunityContextFilter;
 import org.lucoenergia.conluz.infrastructure.shared.web.error.ConluzAccessDeniedHandler;
 import org.lucoenergia.conluz.infrastructure.shared.security.auth.ConluzAuthenticationEntryPoint;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,17 +43,20 @@ public class WebSecurityConfig {
     private final GlobalExceptionFilter globalExceptionFilter;
     private final ObjectMapper objectMapper;
     private final ErrorBuilder errorBuilder;
+    private final CommunityContextFilter communityContextFilter;
 
     public WebSecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                              JwtAuthenticationExceptionFilter jwtAuthenticationExceptionFilter,
                              AuthenticationProvider authenticationProvider,
-                             GlobalExceptionFilter globalExceptionFilter, ObjectMapper objectMapper, ErrorBuilder errorBuilder) {
+                             GlobalExceptionFilter globalExceptionFilter, ObjectMapper objectMapper,
+                             ErrorBuilder errorBuilder, CommunityContextFilter communityContextFilter) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.jwtAuthenticationExceptionFilter = jwtAuthenticationExceptionFilter;
         this.authenticationProvider = authenticationProvider;
         this.globalExceptionFilter = globalExceptionFilter;
         this.objectMapper = objectMapper;
         this.errorBuilder = errorBuilder;
+        this.communityContextFilter = communityContextFilter;
     }
 
     @Bean
@@ -76,6 +80,7 @@ public class WebSecurityConfig {
                 )
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(communityContextFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationExceptionFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(globalExceptionFilter, JwtAuthenticationExceptionFilter.class)
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/auth/JwtAuthRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/auth/JwtAuthRepository.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.apache.commons.collections4.map.HashedMap;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMembership;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.auth.AuthRepository;
 import org.lucoenergia.conluz.domain.admin.user.auth.Token;
@@ -15,6 +16,7 @@ import java.security.Key;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,6 +28,8 @@ public class JwtAuthRepository implements AuthRepository {
     private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthRepository.class);
 
     private static final String CUSTOM_CLAIM_ROLE = "role";
+    private static final String CUSTOM_CLAIM_IS_PLATFORM_ADMIN = "is_platform_admin";
+    private static final String CUSTOM_CLAIM_COMMUNITY_MEMBERSHIPS = "community_memberships";
 
     private final JwtConfiguration jwtConfiguration;
 
@@ -54,7 +58,31 @@ public class JwtAuthRepository implements AuthRepository {
     private Map<String, Object> getCustomClaims(User user) {
         Map<String, Object> claims = new HashedMap<>();
         claims.put(CUSTOM_CLAIM_ROLE, user.getRole().name());
+        claims.put(CUSTOM_CLAIM_IS_PLATFORM_ADMIN, user.isPlatformAdmin());
+        Map<String, String> membershipMap = new HashMap<>();
+        if (user.getMemberships() != null) {
+            for (CommunityMembership m : user.getMemberships()) {
+                membershipMap.put(m.getCommunity().getId().toString(), m.getRole().name());
+            }
+        }
+        claims.put(CUSTOM_CLAIM_COMMUNITY_MEMBERSHIPS, membershipMap);
         return claims;
+    }
+
+    @Override
+    public boolean isPlatformAdmin(Token token) {
+        Object claim = getAllClaims(token).get(CUSTOM_CLAIM_IS_PLATFORM_ADMIN);
+        return Boolean.TRUE.equals(claim);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map<String, String> getCommunityMemberships(Token token) {
+        Object claim = getAllClaims(token).get(CUSTOM_CLAIM_COMMUNITY_MEMBERSHIPS);
+        if (claim instanceof Map) {
+            return (Map<String, String>) claim;
+        }
+        return Map.of();
     }
 
     @Override

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/auth/JwtAuthenticationFilter.java
@@ -62,7 +62,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         userId = authRepository.getUserIdFromToken(token);
 
-        if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+        if (userId == null) {
+            throw new InvalidTokenException(tokenString.get());
+        }
+
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
             User user = (User) userDetailsService.loadUserByUsername(userId.toString());
 
             if (authRepository.isTokenValid(token, user)) {
@@ -76,9 +80,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             } else {
                 throw new InvalidTokenException(tokenString.get());
             }
-        } else {
-            throw new InvalidTokenException(tokenString.get());
         }
+        // If authentication is already set by a prior filter invocation, proceed without re-processing.
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/community/CommunityContext.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/community/CommunityContext.java
@@ -1,0 +1,26 @@
+package org.lucoenergia.conluz.infrastructure.shared.security.community;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequestScope
+public class CommunityContext {
+
+    private UUID activeCommunityId;
+
+    public Optional<UUID> getActiveCommunityId() {
+        return Optional.ofNullable(activeCommunityId);
+    }
+
+    public void setActiveCommunityId(UUID communityId) {
+        this.activeCommunityId = communityId;
+    }
+
+    public boolean isSet() {
+        return activeCommunityId != null;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/community/CommunityContextFilter.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/security/community/CommunityContextFilter.java
@@ -1,0 +1,118 @@
+package org.lucoenergia.conluz.infrastructure.shared.security.community;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMembership;
+import org.lucoenergia.conluz.domain.admin.user.Role;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.infrastructure.shared.error.ErrorBuilder;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class CommunityContextFilter extends OncePerRequestFilter {
+
+    public static final String COMMUNITY_ID_HEADER = "X-Community-Id";
+
+    private final CommunityContext communityContext;
+    private final ObjectMapper objectMapper;
+    private final ErrorBuilder errorBuilder;
+
+    public CommunityContextFilter(CommunityContext communityContext,
+                                  ObjectMapper objectMapper,
+                                  ErrorBuilder errorBuilder) {
+        this.communityContext = communityContext;
+        this.objectMapper = objectMapper;
+        this.errorBuilder = errorBuilder;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || !(authentication.getPrincipal() instanceof User)) {
+            // Not authenticated — skip community context resolution
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        User user = (User) authentication.getPrincipal();
+        String communityIdHeader = request.getHeader(COMMUNITY_ID_HEADER);
+
+        if (communityIdHeader != null && !communityIdHeader.isBlank()) {
+            // Parse the provided community id
+            UUID communityId;
+            try {
+                communityId = UUID.fromString(communityIdHeader.trim());
+            } catch (IllegalArgumentException e) {
+                writeBadRequestResponse(response, "Invalid X-Community-Id header value: not a valid UUID");
+                return;
+            }
+
+            // Platform admin or ADMIN role can use any community without membership check
+            if (user.getRole() == Role.ADMIN || Boolean.TRUE.equals(user.isPlatformAdmin())) {
+                communityContext.setActiveCommunityId(communityId);
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // Check membership
+            boolean isMember = user.getMemberships() != null && user.getMemberships().stream()
+                    .anyMatch(m -> communityId.equals(m.getCommunity().getId())
+                            && Boolean.TRUE.equals(m.isEnabled()));
+
+            if (!isMember) {
+                writeForbiddenResponse(response);
+                return;
+            }
+
+            communityContext.setActiveCommunityId(communityId);
+        } else {
+            // No header — auto-detect from memberships
+            if (user.getMemberships() != null) {
+                List<CommunityMembership> activeMemberships = user.getMemberships().stream()
+                        .filter(m -> Boolean.TRUE.equals(m.isEnabled()))
+                        .toList();
+
+                if (activeMemberships.size() == 1) {
+                    communityContext.setActiveCommunityId(activeMemberships.get(0).getCommunity().getId());
+                }
+                // If 0 or more than 1 active memberships, leave unset
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void writeBadRequestResponse(HttpServletResponse response, String message) throws IOException {
+        ResponseEntity<RestError> entity = errorBuilder.build(message, HttpStatus.BAD_REQUEST);
+        response.setStatus(HttpStatus.BAD_REQUEST.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), entity.getBody());
+    }
+
+    private void writeForbiddenResponse(HttpServletResponse response) throws IOException {
+        ResponseEntity<RestError> entity = errorBuilder.build(
+                "Access denied: user is not a member of the requested community",
+                HttpStatus.FORBIDDEN);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), entity.getBody());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Multi-community feature flag
+conluz.multi-community.enabled=false
+
 # ConLuz global configuration
 conluz.time.zone.id=Europe/Madrid
 conluz.i18n.locale.default=es

--- a/src/test/java/org/lucoenergia/conluz/domain/admin/user/UserTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/admin/user/UserTest.java
@@ -1,0 +1,136 @@
+package org.lucoenergia.conluz.domain.admin.user;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMembership;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.CommunityRole;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserTest {
+
+    @Test
+    void partnerRoleGrantsOnlyPartnerAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(1, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+    }
+
+    @Test
+    void adminRoleGrantsOnlyAdminAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.ADMIN);
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(1, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_ADMIN"));
+    }
+
+    @Test
+    void platformAdminFlagAddsPlatformAdminAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        user.setPlatformAdmin(true);
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(2, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+        assertTrue(containsAuthority(authorities, "ROLE_PLATFORM_ADMIN"));
+    }
+
+    @Test
+    void activeCommunityAdminMembershipGrantsCommunityAdminAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        user.setMemberships(List.of(membershipWith(user, CommunityRole.COMMUNITY_ADMIN, true)));
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(2, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+        assertTrue(containsAuthority(authorities, "ROLE_COMMUNITY_ADMIN"));
+    }
+
+    @Test
+    void disabledCommunityAdminMembershipDoesNotGrantCommunityAdminAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        user.setMemberships(List.of(membershipWith(user, CommunityRole.COMMUNITY_ADMIN, false)));
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(1, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+        assertFalse(containsAuthority(authorities, "ROLE_COMMUNITY_ADMIN"));
+    }
+
+    @Test
+    void communityMemberMembershipDoesNotGrantCommunityAdminAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        user.setMemberships(List.of(membershipWith(user, CommunityRole.COMMUNITY_MEMBER, true)));
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(1, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+        assertFalse(containsAuthority(authorities, "ROLE_COMMUNITY_ADMIN"));
+    }
+
+    @Test
+    void nullMembershipsDoNotGrantCommunityAdminAuthority() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        user.setMemberships(null);
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(1, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+        assertFalse(containsAuthority(authorities, "ROLE_COMMUNITY_ADMIN"));
+    }
+
+    @Test
+    void allFlagsSetGrantsAllAuthorities() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        user.setPlatformAdmin(true);
+        user.setMemberships(List.of(membershipWith(user, CommunityRole.COMMUNITY_ADMIN, true)));
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+
+        assertEquals(3, authorities.size());
+        assertTrue(containsAuthority(authorities, "ROLE_PARTNER"));
+        assertTrue(containsAuthority(authorities, "ROLE_PLATFORM_ADMIN"));
+        assertTrue(containsAuthority(authorities, "ROLE_COMMUNITY_ADMIN"));
+    }
+
+    private CommunityMembership membershipWith(User user, CommunityRole communityRole, boolean enabled) {
+        Community community = CommunityMother.random().build();
+        return new CommunityMembership.Builder()
+                .withId(UUID.randomUUID())
+                .withUser(user)
+                .withCommunity(community)
+                .withRole(communityRole)
+                .withEnabled(enabled)
+                .build();
+    }
+
+    private boolean containsAuthority(Collection<? extends GrantedAuthority> authorities, String authority) {
+        return authorities.stream().anyMatch(a -> a.getAuthority().equals(authority));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/community/access/CommunityAccessGuardTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/community/access/CommunityAccessGuardTest.java
@@ -1,0 +1,270 @@
+package org.lucoenergia.conluz.infrastructure.admin.community.access;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMembership;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.CommunityRole;
+import org.lucoenergia.conluz.domain.admin.community.access.CommunityAccessGuard;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.user.Role;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.auth.AuthService;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityAccessGuardTest {
+
+    @Mock
+    private AuthService authService;
+
+    private CommunityAccessGuard guard() {
+        return new CommunityAccessGuardImpl(authService);
+    }
+
+    // --- canReadSupply ---
+
+    @Test
+    void canReadSupply_returnsTrue_whenUserIsAdmin() {
+        User admin = UserMother.randomUser();
+        admin.setRole(Role.ADMIN);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(admin));
+
+        Supply supply = supplyOwnedBy(UUID.randomUUID());
+
+        assertTrue(guard().canReadSupply(supply));
+    }
+
+    @Test
+    void canReadSupply_returnsTrue_whenUserIsOwner() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        Supply supply = supplyOwnedBy(user.getId());
+
+        assertTrue(guard().canReadSupply(supply));
+    }
+
+    @Test
+    void canReadSupply_returnsTrue_whenUserIsMemberOfSupplyCommunity() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_MEMBER, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+
+        assertTrue(guard().canReadSupply(supply));
+    }
+
+    @Test
+    void canReadSupply_returnsFalse_whenUserIsNotMemberOfSupplyCommunity() {
+        Community communityA = CommunityMother.random().build();
+        Community communityB = CommunityMother.random().build();
+        User user = userWithMembership(communityA, CommunityRole.COMMUNITY_MEMBER, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        Supply supply = supplyInCommunity(UUID.randomUUID(), communityB);
+
+        assertFalse(guard().canReadSupply(supply));
+    }
+
+    @Test
+    void canReadSupply_returnsFalse_whenMembershipIsDisabled() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_MEMBER, false);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+
+        assertFalse(guard().canReadSupply(supply));
+    }
+
+    @Test
+    void canReadSupply_returnsFalse_whenNoAuthenticatedUser() {
+        when(authService.getCurrentUser()).thenReturn(Optional.empty());
+
+        assertFalse(guard().canReadSupply(supplyOwnedBy(UUID.randomUUID())));
+    }
+
+    // --- canEditSupply ---
+
+    @Test
+    void canEditSupply_returnsTrue_whenUserIsAdmin() {
+        User admin = UserMother.randomUser();
+        admin.setRole(Role.ADMIN);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(admin));
+
+        assertTrue(guard().canEditSupply(supplyOwnedBy(UUID.randomUUID())));
+    }
+
+    @Test
+    void canEditSupply_returnsTrue_whenUserIsOwner() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertTrue(guard().canEditSupply(supplyOwnedBy(user.getId())));
+    }
+
+    @Test
+    void canEditSupply_returnsTrue_whenUserIsCommunityAdmin() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_ADMIN, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+
+        assertTrue(guard().canEditSupply(supply));
+    }
+
+    @Test
+    void canEditSupply_returnsFalse_whenUserIsCommunityMember() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_MEMBER, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+
+        assertFalse(guard().canEditSupply(supply));
+    }
+
+    // --- canReadCommunity ---
+
+    @Test
+    void canReadCommunity_returnsTrue_whenUserIsAdmin() {
+        User admin = UserMother.randomUser();
+        admin.setRole(Role.ADMIN);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(admin));
+
+        assertTrue(guard().canReadCommunity(UUID.randomUUID()));
+    }
+
+    @Test
+    void canReadCommunity_returnsTrue_whenUserIsMember() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_MEMBER, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertTrue(guard().canReadCommunity(community.getId()));
+    }
+
+    @Test
+    void canReadCommunity_returnsFalse_whenUserIsNotMember() {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertFalse(guard().canReadCommunity(UUID.randomUUID()));
+    }
+
+    // --- canManageCommunity ---
+
+    @Test
+    void canManageCommunity_returnsTrue_whenUserIsAdmin() {
+        User admin = UserMother.randomUser();
+        admin.setRole(Role.ADMIN);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(admin));
+
+        assertTrue(guard().canManageCommunity(UUID.randomUUID()));
+    }
+
+    @Test
+    void canManageCommunity_returnsTrue_whenUserIsCommunityAdmin() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_ADMIN, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertTrue(guard().canManageCommunity(community.getId()));
+    }
+
+    @Test
+    void canManageCommunity_returnsFalse_whenUserIsCommunityMember() {
+        Community community = CommunityMother.random().build();
+        User user = userWithMembership(community, CommunityRole.COMMUNITY_MEMBER, true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertFalse(guard().canManageCommunity(community.getId()));
+    }
+
+    // --- canManagePlatform ---
+
+    @Test
+    void canManagePlatform_returnsTrue_whenUserIsPlatformAdmin() {
+        User user = UserMother.randomUser();
+        user.setPlatformAdmin(true);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertTrue(guard().canManagePlatform());
+    }
+
+    @Test
+    void canManagePlatform_returnsFalse_whenUserIsNotPlatformAdmin() {
+        User user = UserMother.randomUser();
+        user.setPlatformAdmin(false);
+        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+
+        assertFalse(guard().canManagePlatform());
+    }
+
+    @Test
+    void canManagePlatform_returnsFalse_whenNoAuthenticatedUser() {
+        when(authService.getCurrentUser()).thenReturn(Optional.empty());
+
+        assertFalse(guard().canManagePlatform());
+    }
+
+    // --- helpers ---
+
+    private Supply supplyOwnedBy(UUID ownerId) {
+        User owner = new User.Builder().id(ownerId).build();
+        return new Supply.Builder()
+                .withId(UUID.randomUUID())
+                .withCode("ES001")
+                .withUser(owner)
+                .withName("Supply")
+                .withAddress("Address")
+                .withPartitionCoefficient(1.0f)
+                .withEnabled(true)
+                .build();
+    }
+
+    private Supply supplyInCommunity(UUID ownerId, Community community) {
+        User owner = new User.Builder().id(ownerId).build();
+        return new Supply.Builder()
+                .withId(UUID.randomUUID())
+                .withCode("ES001")
+                .withUser(owner)
+                .withCommunity(community)
+                .withName("Supply")
+                .withAddress("Address")
+                .withPartitionCoefficient(1.0f)
+                .withEnabled(true)
+                .build();
+    }
+
+    private User userWithMembership(Community community, CommunityRole communityRole, boolean enabled) {
+        User user = UserMother.randomUser();
+        user.setRole(Role.PARTNER);
+        CommunityMembership membership = new CommunityMembership.Builder()
+                .withId(UUID.randomUUID())
+                .withUser(user)
+                .withCommunity(community)
+                .withRole(communityRole)
+                .withEnabled(enabled)
+                .build();
+        user.setMemberships(List.of(membership));
+        return user;
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyServiceTest.java
@@ -1,11 +1,13 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply.get;
 
 import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.access.CommunityAccessGuard;
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyService;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.auth.AuthService;
 import org.lucoenergia.conluz.domain.shared.UserId;
 import org.mockito.Mockito;
 import org.springframework.security.access.AccessDeniedException;
@@ -20,7 +22,9 @@ import static org.mockito.Mockito.*;
 class GetSupplyServiceTest {
 
     private final GetSupplyRepository repository = Mockito.mock(GetSupplyRepository.class);
-    private final GetSupplyService service = new GetSupplyServiceImpl(repository, null);
+    private final AuthService authService = Mockito.mock(AuthService.class);
+    private final CommunityAccessGuard communityAccessGuard = Mockito.mock(CommunityAccessGuard.class);
+    private final GetSupplyService service = new GetSupplyServiceImpl(repository, authService, communityAccessGuard);
 
     @Test
     void getByUserIdWithAuthorization_shouldReturnSuppliesWhenUserIsAdmin() {

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyServiceUnitTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyServiceUnitTest.java
@@ -1,12 +1,11 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply.get;
 
 import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.access.CommunityAccessGuard;
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyService;
-import org.lucoenergia.conluz.domain.admin.user.Role;
-import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.auth.AuthService;
 import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.mockito.Mockito;
@@ -23,11 +22,12 @@ class GetSupplyServiceUnitTest {
 
     private final GetSupplyRepository repository = Mockito.mock(GetSupplyRepository.class);
     private final AuthService authService = Mockito.mock(AuthService.class);
+    private final CommunityAccessGuard communityAccessGuard = Mockito.mock(CommunityAccessGuard.class);
 
-    private final GetSupplyService service = new GetSupplyServiceImpl(repository, authService);
+    private final GetSupplyService service = new GetSupplyServiceImpl(repository, authService, communityAccessGuard);
 
     @Test
-    void shouldReturnSupplyWhenUserIsAdmin() {
+    void shouldReturnSupplyWhenUserCanRead() {
         SupplyId supplyId = SupplyId.of(UUID.randomUUID());
         Supply supply = new Supply.Builder()
                 .withId(supplyId.getId())
@@ -38,27 +38,20 @@ class GetSupplyServiceUnitTest {
                 .withEnabled(true)
                 .build();
 
-        User adminUser = new User();
-        adminUser.setRole(Role.ADMIN);
-
         when(repository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(authService.getCurrentUser()).thenReturn(Optional.of(adminUser));
+        when(communityAccessGuard.canReadSupply(supply)).thenReturn(true);
 
         Supply result = service.getById(supplyId);
 
         assertNotNull(result);
         assertEquals(supply, result);
         verify(repository).findById(supplyId);
-        verify(authService).getCurrentUser();
+        verify(communityAccessGuard).canReadSupply(supply);
     }
 
     @Test
-    void shouldReturnSupplyWhenUserIsOwner() {
+    void shouldThrowAccessDeniedExceptionWhenCannotReadSupply() {
         SupplyId supplyId = SupplyId.of(UUID.randomUUID());
-        User owner = new User();
-        owner.setId(UUID.randomUUID());
-        owner.setRole(Role.PARTNER);
-
         Supply supply = new Supply.Builder()
                 .withId(supplyId.getId())
                 .withCode("SUP123")
@@ -66,47 +59,15 @@ class GetSupplyServiceUnitTest {
                 .withAddress("123 Test Street")
                 .withPartitionCoefficient(1.0f)
                 .withEnabled(true)
-                .withUser(owner)
                 .build();
 
         when(repository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(authService.getCurrentUser()).thenReturn(Optional.of(owner));
-
-        Supply result = service.getById(supplyId);
-
-        assertNotNull(result);
-        assertEquals(supply, result);
-        verify(repository).findById(supplyId);
-        verify(authService).getCurrentUser();
-    }
-
-    @Test
-    void shouldThrowAccessDeniedExceptionWhenUserIsNotOwnerOrAdmin() {
-        SupplyId supplyId = SupplyId.of(UUID.randomUUID());
-        User user = new User();
-        user.setId(UUID.randomUUID());
-        user.setRole(Role.PARTNER);
-
-        User owner = new User();
-        owner.setId(UUID.randomUUID());
-
-        Supply supply = new Supply.Builder()
-                .withId(supplyId.getId())
-                .withCode("SUP123")
-                .withName("Test Supply")
-                .withAddress("123 Test Street")
-                .withPartitionCoefficient(1.0f)
-                .withEnabled(true)
-                .withUser(owner)
-                .build();
-
-        when(repository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(authService.getCurrentUser()).thenReturn(Optional.of(user));
+        when(communityAccessGuard.canReadSupply(supply)).thenReturn(false);
 
         assertThrows(AccessDeniedException.class, () -> service.getById(supplyId));
 
         verify(repository).findById(supplyId);
-        verify(authService).getCurrentUser();
+        verify(communityAccessGuard).canReadSupply(supply);
     }
 
     @Test
@@ -118,27 +79,5 @@ class GetSupplyServiceUnitTest {
         assertThrows(SupplyNotFoundException.class, () -> service.getById(supplyId));
 
         verify(repository).findById(supplyId);
-    }
-
-    @Test
-    void shouldThrowAccessDeniedExceptionWhenNoUserIsAuthenticated() {
-        SupplyId supplyId = SupplyId.of(UUID.randomUUID());
-
-        Supply supply = new Supply.Builder()
-                .withId(supplyId.getId())
-                .withCode("SUP123")
-                .withName("Test Supply")
-                .withAddress("123 Test Street")
-                .withPartitionCoefficient(1.0f)
-                .withEnabled(true)
-                .build();
-
-        when(repository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(authService.getCurrentUser()).thenReturn(Optional.empty());
-
-        assertThrows(AccessDeniedException.class, () -> service.getById(supplyId));
-
-        verify(repository).findById(supplyId);
-        verify(authService).getCurrentUser();
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/shared/security/community/CommunityIsolationIntegrationTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/shared/security/community/CommunityIsolationIntegrationTest.java
@@ -1,0 +1,176 @@
+package org.lucoenergia.conluz.infrastructure.shared.security.community;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.CommunityRole;
+import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.Role;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityEntity;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityMembershipEntity;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityMembershipJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class CommunityIsolationIntegrationTest extends BaseControllerTest {
+
+    @Autowired
+    private CreateUserRepository createUserRepository;
+    @Autowired
+    private CreateCommunityRepository createCommunityRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CommunityMembershipJpaRepository communityMembershipJpaRepository;
+    @Autowired
+    private CommunityJpaRepository communityJpaRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private Community communityA;
+    private Community communityB;
+    private User memberA;
+    private User memberB;
+    private Supply supplyA;
+    private Supply supplyB;
+
+    @BeforeEach
+    void setupCommunities() {
+        // Create two communities
+        communityA = createCommunityRepository.create(CommunityMother.random().build());
+        communityB = createCommunityRepository.create(CommunityMother.random().build());
+
+        // Create member users
+        memberA = UserMother.randomUser();
+        memberA.setRole(Role.PARTNER);
+        memberA.enable();
+        createUserRepository.create(memberA);
+
+        memberB = UserMother.randomUser();
+        memberB.setRole(Role.PARTNER);
+        memberB.enable();
+        createUserRepository.create(memberB);
+
+        // Create memberships
+        createMembership(memberA, communityA, CommunityRole.COMMUNITY_MEMBER);
+        createMembership(memberB, communityB, CommunityRole.COMMUNITY_MEMBER);
+
+        // Create supplies assigned to respective communities
+        Supply supplyADomain = SupplyMother.random(memberA)
+                .withCommunity(communityA)
+                .withEnabled(true)
+                .build();
+        supplyA = createSupplyRepository.create(supplyADomain, UserId.of(memberA.getId()));
+
+        Supply supplyBDomain = SupplyMother.random(memberB)
+                .withCommunity(communityB)
+                .withEnabled(true)
+                .build();
+        supplyB = createSupplyRepository.create(supplyBDomain, UserId.of(memberB.getId()));
+    }
+
+    @Test
+    void memberACanAccessTheirOwnCommunitySupply() throws Exception {
+        String tokenA = loginUser(memberA);
+
+        mockMvc.perform(get("/api/v1/supplies/" + supplyA.getId())
+                        .header("Authorization", tokenA)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void memberAWithCorrectCommunityHeaderCanAccessTheirSupply() throws Exception {
+        String tokenA = loginUser(memberA);
+
+        mockMvc.perform(get("/api/v1/supplies/" + supplyA.getId())
+                        .header("Authorization", tokenA)
+                        .header(CommunityContextFilter.COMMUNITY_ID_HEADER, communityA.getId().toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void memberAWithWrongCommunityHeaderGetsForbidden() throws Exception {
+        String tokenA = loginUser(memberA);
+
+        mockMvc.perform(get("/api/v1/supplies/" + supplyA.getId())
+                        .header("Authorization", tokenA)
+                        .header(CommunityContextFilter.COMMUNITY_ID_HEADER, communityB.getId().toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void memberACannotAccessCommunitiyBSupply() throws Exception {
+        String tokenA = loginUser(memberA);
+
+        mockMvc.perform(get("/api/v1/supplies/" + supplyB.getId())
+                        .header("Authorization", tokenA)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void memberBCannotAccessCommunityASupply() throws Exception {
+        String tokenB = loginUser(memberB);
+
+        mockMvc.perform(get("/api/v1/supplies/" + supplyA.getId())
+                        .header("Authorization", tokenB)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void invalidCommunityIdHeaderReturnsBadRequest() throws Exception {
+        String tokenA = loginUser(memberA);
+
+        mockMvc.perform(get("/api/v1/supplies/" + supplyA.getId())
+                        .header("Authorization", tokenA)
+                        .header(CommunityContextFilter.COMMUNITY_ID_HEADER, "not-a-uuid")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    private void createMembership(User user, Community community, CommunityRole role) {
+        UserEntity userEntity = userRepository.findByPersonalId(user.getPersonalId())
+                .orElseThrow(() -> new IllegalStateException("User not found: " + user.getPersonalId()));
+        CommunityEntity communityEntity = communityJpaRepository.findById(community.getId())
+                .orElseThrow(() -> new IllegalStateException("Community not found: " + community.getId()));
+
+        CommunityMembershipEntity membership = new CommunityMembershipEntity.Builder()
+                .withId(UUID.randomUUID())
+                .withUser(userEntity)
+                .withCommunity(communityEntity)
+                .withRole(role)
+                .withEnabled(true)
+                .build();
+        communityMembershipJpaRepository.save(membership);
+    }
+}


### PR DESCRIPTION
- Add CommunityMembership list to User domain object with updated getAuthorities() granting ROLE_COMMUNITY_ADMIN
- Add isPlatformAdmin and community_memberships claims to JWT tokens (JwtAuthRepository)
- Add AuthRepository.isPlatformAdmin() and getCommunityMemberships() methods
- Load user memberships on every authentication via UserDetailsServiceFromDatabase
- Create CommunityAccessGuard port and CommunityAccessGuardImpl for supply/community access control
- Create CommunityContext (request-scoped) and CommunityContextFilter for X-Community-Id header validation
- Wire CommunityContextFilter into security filter chain after JwtAuthenticationFilter
- Refactor GetDatadisConsumptionServiceImpl to use CommunityAccessGuard instead of inline role checks
- Refactor GetSupplyServiceImpl.getById() to use CommunityAccessGuard
- Add JpaSpecificationExecutor to SupplyRepository and create SupplySpecifications helpers
- Add feature flag conluz.multi-community.enabled=false
- Add CommunityIsolationIntegrationTest verifying cross-community access denial
- Fix GetSupplyServiceTest and GetSupplyServiceUnitTest for new constructor signature