### PR TITLE
Feature/conluz 197

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/production/get/GetProductionRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/get/GetProductionRepository.java
@@ -15,9 +15,6 @@ public interface GetProductionRepository {
      */
     InstantProduction getInstantProduction(Collection<String> stationCodes);
 
-    List<ProductionByTime> getHourlyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
-                                                             Float partitionCoefficient);
-
     /**
      * Hourly production for the given station codes, multiplied by {@code partitionCoefficient}.
      * An empty {@code stationCodes} collection yields an empty list.
@@ -26,13 +23,7 @@ public interface GetProductionRepository {
                                                              Float partitionCoefficient, Collection<String> stationCodes);
 
     List<ProductionByTime> getDailyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
-                                                             Float partitionCoefficient);
-
-    List<ProductionByTime> getDailyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
                                                             Float partitionCoefficient, Collection<String> stationCodes);
-
-    List<ProductionByTime> getMonthlyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
-                                                            Float partitionCoefficient);
 
     List<ProductionByTime> getMonthlyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
                                                             Float partitionCoefficient, Collection<String> stationCodes);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionRepositoryInflux.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionRepositoryInflux.java
@@ -75,12 +75,6 @@ public class GetProductionRepositoryInflux implements GetProductionRepository {
 
     @Override
     public List<ProductionByTime> getHourlyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
-                                                                    Float partitionCoefficient) {
-        return queryHourly(startDate, endDate, partitionCoefficient, "");
-    }
-
-    @Override
-    public List<ProductionByTime> getHourlyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
                                                                     Float partitionCoefficient,
                                                                     Collection<String> stationCodes) {
         if (stationCodes == null || stationCodes.isEmpty()) {
@@ -91,6 +85,12 @@ public class GetProductionRepositoryInflux implements GetProductionRepository {
 
     private List<ProductionByTime> queryHourly(OffsetDateTime startDate, OffsetDateTime endDate,
                                                Float partitionCoefficient, String stationClause) {
+        // Unreachable through the public API today — every public caller already guards on an empty
+        // stationCodes collection before building a non-blank clause. Kept as the actual invariant point
+        // so no future caller (public or private) can ever emit an unrestricted query.
+        if (stationClause == null || stationClause.isBlank()) {
+            return Collections.emptyList();
+        }
         try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
             Query query = new Query(String.format(
                     "SELECT time, \"%s\"*%s FROM \"%s\" WHERE time >= '%s' AND time <= '%s'%s",
@@ -113,13 +113,6 @@ public class GetProductionRepositoryInflux implements GetProductionRepository {
 
     @Override
     public List<ProductionByTime> getDailyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
-                                                                   Float partitionCoefficient) {
-        return getProductionByRangeOfDatesGroupedByDuration(startDate, endDate,
-                partitionCoefficient, InfluxDuration.DAILY, "");
-    }
-
-    @Override
-    public List<ProductionByTime> getDailyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
                                                                    Float partitionCoefficient,
                                                                    Collection<String> stationCodes) {
         if (stationCodes == null || stationCodes.isEmpty()) {
@@ -127,13 +120,6 @@ public class GetProductionRepositoryInflux implements GetProductionRepository {
         }
         return getProductionByRangeOfDatesGroupedByDuration(startDate, endDate,
                 partitionCoefficient, InfluxDuration.DAILY, stationCodeAndClause(stationCodes));
-    }
-
-    @Override
-    public List<ProductionByTime> getMonthlyProductionByRangeOfDates(OffsetDateTime startDate, OffsetDateTime endDate,
-                                                                     Float partitionCoefficient) {
-        return queryAggregatedMeasurement(HuaweiConfig.HUAWEI_MONTHLY_PRODUCTION_MEASUREMENT,
-                startDate, endDate, partitionCoefficient, "", HuaweiHourlyProductionMonthlyPoint.class);
     }
 
     @Override
@@ -163,6 +149,12 @@ public class GetProductionRepositoryInflux implements GetProductionRepository {
     private <T> List<ProductionByTime> queryAggregatedMeasurement(String measurement, OffsetDateTime startDate,
                                                                   OffsetDateTime endDate, Float partitionCoefficient,
                                                                   String stationClause, Class<T> pointType) {
+        // Unreachable through the public API today — every public caller already guards on an empty
+        // stationCodes collection before building a non-blank clause. Kept as the actual invariant point
+        // so no future caller (public or private) can ever emit an unrestricted query.
+        if (stationClause == null || stationClause.isBlank()) {
+            return Collections.emptyList();
+        }
         try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
             Query query = new Query(String.format(
                     "SELECT \"inverter_power\" FROM \"%s\" WHERE time >= '%s' AND time <= '%s'%s",
@@ -211,6 +203,12 @@ public class GetProductionRepositoryInflux implements GetProductionRepository {
                                                                                 Float partitionCoefficient,
                                                                                 String duration,
                                                                                 String stationClause) {
+        // Unreachable through the public API today — every public caller already guards on an empty
+        // stationCodes collection before building a non-blank clause. Kept as the actual invariant point
+        // so no future caller (public or private) can ever emit an unrestricted query.
+        if (stationClause == null || stationClause.isBlank()) {
+            return Collections.emptyList();
+        }
         try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
             Query query = new Query(String.format(
                     "SELECT SUM(\"%s\")*%s AS \"%s\" FROM \"%s\" WHERE time >= '%s' AND time <= '%s'%s GROUP BY time(%s)",

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImpl.java
@@ -42,7 +42,7 @@ public class GetProductionServiceImpl implements GetProductionService {
         }
 
         return getProductionRepository.getHourlyProductionByRangeOfDates(startDate,
-                endDate, supply.get().getPartitionCoefficient());
+                endDate, supply.get().getPartitionCoefficient(), resolveStationCodes(supply.get()));
     }
 
     @Override
@@ -54,7 +54,7 @@ public class GetProductionServiceImpl implements GetProductionService {
         }
 
         return getProductionRepository.getDailyProductionByRangeOfDates(startDate,
-                endDate, supply.get().getPartitionCoefficient());
+                endDate, supply.get().getPartitionCoefficient(), resolveStationCodes(supply.get()));
     }
 
     @Override
@@ -66,7 +66,7 @@ public class GetProductionServiceImpl implements GetProductionService {
         }
 
         return getProductionRepository.getMonthlyProductionByRangeOfDates(startDate,
-                endDate, supply.get().getPartitionCoefficient());
+                endDate, supply.get().getPartitionCoefficient(), resolveStationCodes(supply.get()));
     }
 
     // --- Community-scoped variants ---
@@ -146,6 +146,22 @@ public class GetProductionServiceImpl implements GetProductionService {
         Supply supply = requireSupplyInCommunity(id, communityId);
         return getProductionRepository.getYearlyProductionByRangeOfDates(startDate, endDate,
                 supply.getPartitionCoefficient(), getPlantRepository.findPlantCodesByCommunity(communityId));
+    }
+
+    /**
+     * Resolves the InfluxDB station codes contributing to a supply's shared production.
+     * Approximation: production is shared across the whole community via partition coefficients,
+     * and most supplies own no plant of their own, so all plant codes of the supply's community are
+     * used. A supply with no community resolves to no station codes (empty result, never an
+     * unrestricted query) — defensive only; supplies.community_id is NOT NULL in the schema.
+     * Replace with an exact lookup once the (plant_id, supply_id) participation table exists
+     * (phase 2d of the Sharing Agreements epic) and the resolver that consumes it lands (phase 4).
+     */
+    private List<String> resolveStationCodes(Supply supply) {
+        if (supply.getCommunity() == null) {
+            return List.of();
+        }
+        return getPlantRepository.findPlantCodesByCommunity(supply.getCommunity().getId());
     }
 
     /**

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyDailyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyDailyProductionControllerTest.java
@@ -9,6 +9,9 @@ import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
 import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.lucoenergia.conluz.domain.shared.UserId;
 import org.lucoenergia.conluz.infrastructure.production.EnergyProductionInfluxLoader;
 import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
@@ -41,11 +44,20 @@ class GetSupplyDailyProductionControllerTest extends BaseControllerTest {
     @Autowired
     private CreateSupplyRepository createSupplyRepository;
     @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
     private EnergyProductionInfluxLoader energyProductionInfluxLoader;
 
     @BeforeEach
     void beforeEach() {
         energyProductionInfluxLoader.loadData();
+        // Register a plant in the default community whose code matches the seeded InfluxDB station_code,
+        // so the per-supply production query (scoped to the supply's community) resolves data.
+        User plantOwner = createUserRepository.create(UserMother.randomUser());
+        Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
+        createPlantRepository.create(
+                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                SupplyId.of(plantSupply.getId()));
     }
 
     @AfterEach

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyHourlyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyHourlyProductionControllerTest.java
@@ -9,6 +9,9 @@ import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
 import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.lucoenergia.conluz.domain.shared.UserId;
 import org.lucoenergia.conluz.infrastructure.production.EnergyProductionInfluxLoader;
 import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
@@ -41,11 +44,20 @@ class GetSupplyHourlyProductionControllerTest extends BaseControllerTest {
     @Autowired
     private CreateSupplyRepository createSupplyRepository;
     @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
     private EnergyProductionInfluxLoader energyProductionInfluxLoader;
 
     @BeforeEach
     void beforeEach() {
         energyProductionInfluxLoader.loadData();
+        // Register a plant in the default community whose code matches the seeded InfluxDB station_code,
+        // so the per-supply production query (scoped to the supply's community) resolves data.
+        User plantOwner = createUserRepository.create(UserMother.randomUser());
+        Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
+        createPlantRepository.create(
+                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                SupplyId.of(plantSupply.getId()));
     }
 
     @AfterEach

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyMonthlyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyMonthlyProductionControllerTest.java
@@ -9,6 +9,9 @@ import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
 import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.lucoenergia.conluz.domain.shared.UserId;
 import org.lucoenergia.conluz.infrastructure.production.EnergyProductionInfluxLoader;
 import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
@@ -41,11 +44,20 @@ class GetSupplyMonthlyProductionControllerTest extends BaseControllerTest {
     @Autowired
     private CreateSupplyRepository createSupplyRepository;
     @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
     private EnergyProductionInfluxLoader energyProductionInfluxLoader;
 
     @BeforeEach
     void beforeEach() {
         energyProductionInfluxLoader.loadData();
+        // Register a plant in the default community whose code matches the seeded InfluxDB station_code,
+        // so the per-supply production query (scoped to the supply's community) resolves data.
+        User plantOwner = createUserRepository.create(UserMother.randomUser());
+        Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
+        createPlantRepository.create(
+                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                SupplyId.of(plantSupply.getId()));
     }
 
     @AfterEach

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionRepositoryInfluxTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionRepositoryInfluxTest.java
@@ -42,7 +42,8 @@ class GetProductionRepositoryInfluxTest extends BaseIntegrationTest {
         OffsetDateTime endDate = OffsetDateTime.parse("2023-09-01T23:00:00.000+02:00");
         Float partitionCoefficient = 1.0f;
 
-        List<ProductionByTime> result = repository.getHourlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient);
+        List<ProductionByTime> result = repository.getHourlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient,
+                List.of(EnergyProductionInfluxLoader.STATION_CODE));
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -91,7 +92,8 @@ class GetProductionRepositoryInfluxTest extends BaseIntegrationTest {
         OffsetDateTime endDate = OffsetDateTime.parse("2023-09-01T23:00:00.000+02:00");
         Float partitionCoefficient = 0.5f; // 50% partition
 
-        List<ProductionByTime> result = repository.getHourlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient);
+        List<ProductionByTime> result = repository.getHourlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient,
+                List.of(EnergyProductionInfluxLoader.STATION_CODE));
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -116,7 +118,8 @@ class GetProductionRepositoryInfluxTest extends BaseIntegrationTest {
         OffsetDateTime endDate = OffsetDateTime.parse("2023-09-01T23:00:00.000+02:00");
         Float partitionCoefficient = 1.0f;
 
-        List<ProductionByTime> result = repository.getMonthlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient);
+        List<ProductionByTime> result = repository.getMonthlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient,
+                List.of(EnergyProductionInfluxLoader.STATION_CODE));
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -135,7 +138,8 @@ class GetProductionRepositoryInfluxTest extends BaseIntegrationTest {
         OffsetDateTime endDate = OffsetDateTime.parse("2023-09-01T23:00:00.000+02:00");
         Float partitionCoefficient = 0.5f;
 
-        List<ProductionByTime> result = repository.getMonthlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient);
+        List<ProductionByTime> result = repository.getMonthlyProductionByRangeOfDates(startDate, endDate, partitionCoefficient,
+                List.of(EnergyProductionInfluxLoader.STATION_CODE));
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -188,7 +192,8 @@ class GetProductionRepositoryInfluxTest extends BaseIntegrationTest {
         OffsetDateTime endDate = OffsetDateTime.parse("2023-09-01T23:00:00.000+02:00");
         Float partitionCoefficient = 1.0f;
 
-        List<ProductionByTime> result = repository.getDailyProductionByRangeOfDates(startDate, endDate, partitionCoefficient);
+        List<ProductionByTime> result = repository.getDailyProductionByRangeOfDates(startDate, endDate, partitionCoefficient,
+                List.of(EnergyProductionInfluxLoader.STATION_CODE));
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -205,7 +210,8 @@ class GetProductionRepositoryInfluxTest extends BaseIntegrationTest {
         OffsetDateTime endDate = OffsetDateTime.parse("2023-09-01T23:00:00.000+02:00");
         Float partitionCoefficient = 0.5f;
 
-        List<ProductionByTime> result = repository.getDailyProductionByRangeOfDates(startDate, endDate, partitionCoefficient);
+        List<ProductionByTime> result = repository.getDailyProductionByRangeOfDates(startDate, endDate, partitionCoefficient,
+                List.of(EnergyProductionInfluxLoader.STATION_CODE));
 
         assertNotNull(result);
         assertFalse(result.isEmpty());

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImplIntegrationTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImplIntegrationTest.java
@@ -1,0 +1,115 @@
+package org.lucoenergia.conluz.infrastructure.production.get;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.ProductionByTime;
+import org.lucoenergia.conluz.domain.production.get.GetProductionService;
+import org.lucoenergia.conluz.domain.production.huawei.HuaweiConfig;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.production.ProductionPoint;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.lucoenergia.conluz.infrastructure.shared.db.influxdb.InfluxDbConnectionManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the cross-community leakage in per-supply production queries: without a station
+ * restriction derived from the supply's own community, a supply reports production from every
+ * plant of every community, not just its own.
+ */
+@SpringBootTest
+class GetProductionServiceImplIntegrationTest extends BaseIntegrationTest {
+
+    private static final String STATION_CODE_A = "NE=99900001";
+    private static final String STATION_CODE_B = "NE=99900002";
+    private static final OffsetDateTime START_DATE = OffsetDateTime.parse("2023-09-01T00:00:00.000+02:00");
+    private static final OffsetDateTime END_DATE = OffsetDateTime.parse("2023-09-01T01:00:00.000+02:00");
+    private static final long SEEDED_HOUR_NANOS = 1693519200000000000L; // 2023-09-01T00:00:00Z
+
+    @Autowired
+    private GetProductionService getProductionService;
+    @Autowired
+    private CreateCommunityRepository createCommunityRepository;
+    @Autowired
+    private CreateUserRepository createUserRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
+    private InfluxDbConnectionManager influxDbConnectionManager;
+
+    private void seedStationProduction(String stationCode, double inverterPower) {
+        try (InfluxDB connection = influxDbConnectionManager.getConnection()) {
+            BatchPoints batchPoints = influxDbConnectionManager.createBatchPoints();
+            batchPoints.point(Point.measurement(HuaweiConfig.HUAWEI_HOURLY_PRODUCTION_MEASUREMENT)
+                    .time(SEEDED_HOUR_NANOS, TimeUnit.NANOSECONDS)
+                    .tag("station_code", stationCode)
+                    .addField(ProductionPoint.INVERTER_POWER, inverterPower)
+                    .build());
+            connection.write(batchPoints);
+        }
+    }
+
+    private Supply createSupplyInNewCommunityWithPlant(String stationCode) {
+        Community community = createCommunityRepository.create(CommunityMother.random().build());
+        User user = createUserRepository.create(UserMother.randomUser());
+        Supply supply = createSupplyRepository.create(
+                SupplyMother.random().withPartitionCoefficient(1.0f).build(),
+                UserId.of(user.getId()), community.getId());
+        createPlantRepository.create(
+                PlantMother.random(supply).withCode(stationCode).build(), SupplyId.of(supply.getId()));
+        return supply;
+    }
+
+    @Test
+    void getHourlyProductionByRangeOfDatesAndSupply_reportsOnlyOwnCommunityProduction() {
+        seedStationProduction(STATION_CODE_A, 10.0d);
+        seedStationProduction(STATION_CODE_B, 1000.0d);
+
+        Supply supplyA = createSupplyInNewCommunityWithPlant(STATION_CODE_A);
+        createSupplyInNewCommunityWithPlant(STATION_CODE_B);
+
+        List<ProductionByTime> result = getProductionService.getHourlyProductionByRangeOfDatesAndSupply(
+                START_DATE, END_DATE, SupplyId.of(supplyA.getId()));
+
+        assertEquals(1, result.size());
+        assertEquals(10.0d, result.get(0).getPower(), 0.01d,
+                "Supply A must report only community A's production, not A+B combined");
+    }
+
+    @Test
+    void getHourlyProductionByRangeOfDatesAndSupply_communityWithNoPlantYieldsEmptyResult() {
+        Community communityWithNoPlant = createCommunityRepository.create(CommunityMother.random().build());
+        User user = createUserRepository.create(UserMother.randomUser());
+        Supply supply = createSupplyRepository.create(
+                SupplyMother.random().withPartitionCoefficient(1.0f).build(),
+                UserId.of(user.getId()), communityWithNoPlant.getId());
+
+        List<ProductionByTime> result = getProductionService.getHourlyProductionByRangeOfDatesAndSupply(
+                START_DATE, END_DATE, SupplyId.of(supply.getId()));
+
+        assertTrue(result.isEmpty(), "A community with no plants must yield an empty result, never an unrestricted query");
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceTest.java
@@ -49,18 +49,23 @@ class GetProductionServiceTest {
     @Test
     void getHourlyProductionByRangeOfDatesAndSupply_appliesSupplyPartitionCoefficient() {
         UUID supplyUuid = UUID.randomUUID();
+        UUID communityId = UUID.randomUUID();
         SupplyId supplyId = SupplyId.of(supplyUuid);
-        Supply supply = SupplyMother.random().withId(supplyUuid).withPartitionCoefficient(0.4f).build();
+        Community community = CommunityMother.random().withId(communityId).build();
+        Supply supply = SupplyMother.random().withId(supplyUuid).withPartitionCoefficient(0.4f)
+                .withCommunity(community).build();
+        List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 10d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate, 0.4f))
+        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate, 0.4f, stationCodes))
                 .thenReturn(expected);
 
         List<ProductionByTime> result = service.getHourlyProductionByRangeOfDatesAndSupply(startDate, endDate, supplyId);
 
         assertSame(expected, result);
-        verify(getProductionRepository).getHourlyProductionByRangeOfDates(startDate, endDate, 0.4f);
+        verify(getProductionRepository).getHourlyProductionByRangeOfDates(startDate, endDate, 0.4f, stationCodes);
     }
 
     @Test
@@ -76,18 +81,23 @@ class GetProductionServiceTest {
     @Test
     void getDailyProductionByRangeOfDatesAndSupply_appliesSupplyPartitionCoefficient() {
         UUID supplyUuid = UUID.randomUUID();
+        UUID communityId = UUID.randomUUID();
         SupplyId supplyId = SupplyId.of(supplyUuid);
-        Supply supply = SupplyMother.random().withId(supplyUuid).withPartitionCoefficient(0.25f).build();
+        Community community = CommunityMother.random().withId(communityId).build();
+        Supply supply = SupplyMother.random().withId(supplyUuid).withPartitionCoefficient(0.25f)
+                .withCommunity(community).build();
+        List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 5d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate, 0.25f))
+        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate, 0.25f, stationCodes))
                 .thenReturn(expected);
 
         List<ProductionByTime> result = service.getDailyProductionByRangeOfDatesAndSupply(startDate, endDate, supplyId);
 
         assertSame(expected, result);
-        verify(getProductionRepository).getDailyProductionByRangeOfDates(startDate, endDate, 0.25f);
+        verify(getProductionRepository).getDailyProductionByRangeOfDates(startDate, endDate, 0.25f, stationCodes);
     }
 
     @Test
@@ -103,18 +113,23 @@ class GetProductionServiceTest {
     @Test
     void getMonthlyProductionByRangeOfDatesAndSupply_appliesSupplyPartitionCoefficient() {
         UUID supplyUuid = UUID.randomUUID();
+        UUID communityId = UUID.randomUUID();
         SupplyId supplyId = SupplyId.of(supplyUuid);
-        Supply supply = SupplyMother.random().withId(supplyUuid).withPartitionCoefficient(0.75f).build();
+        Community community = CommunityMother.random().withId(communityId).build();
+        Supply supply = SupplyMother.random().withId(supplyUuid).withPartitionCoefficient(0.75f)
+                .withCommunity(community).build();
+        List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 100d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate, 0.75f))
+        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate, 0.75f, stationCodes))
                 .thenReturn(expected);
 
         List<ProductionByTime> result = service.getMonthlyProductionByRangeOfDatesAndSupply(startDate, endDate, supplyId);
 
         assertSame(expected, result);
-        verify(getProductionRepository).getMonthlyProductionByRangeOfDates(startDate, endDate, 0.75f);
+        verify(getProductionRepository).getMonthlyProductionByRangeOfDates(startDate, endDate, 0.75f, stationCodes);
     }
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceTest.java
@@ -69,6 +69,22 @@ class GetProductionServiceTest {
     }
 
     @Test
+    void getHourlyProductionByRangeOfDatesAndSupply_supplyWithNoCommunityYieldsEmptyStationCodes() {
+        UUID supplyUuid = UUID.randomUUID();
+        SupplyId supplyId = SupplyId.of(supplyUuid);
+        Supply supply = SupplyMother.random().withId(supplyUuid).withCommunity(null).build();
+
+        when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
+        when(getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate,
+                supply.getPartitionCoefficient(), List.of())).thenReturn(List.of());
+
+        List<ProductionByTime> result = service.getHourlyProductionByRangeOfDatesAndSupply(startDate, endDate, supplyId);
+
+        assertEquals(List.of(), result);
+        verifyNoInteractions(getPlantRepository);
+    }
+
+    @Test
     void getHourlyProductionByRangeOfDatesAndSupply_throwsWhenSupplyNotFound() {
         SupplyId supplyId = SupplyId.of(UUID.randomUUID());
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.empty());
@@ -101,6 +117,22 @@ class GetProductionServiceTest {
     }
 
     @Test
+    void getDailyProductionByRangeOfDatesAndSupply_supplyWithNoCommunityYieldsEmptyStationCodes() {
+        UUID supplyUuid = UUID.randomUUID();
+        SupplyId supplyId = SupplyId.of(supplyUuid);
+        Supply supply = SupplyMother.random().withId(supplyUuid).withCommunity(null).build();
+
+        when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
+        when(getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate,
+                supply.getPartitionCoefficient(), List.of())).thenReturn(List.of());
+
+        List<ProductionByTime> result = service.getDailyProductionByRangeOfDatesAndSupply(startDate, endDate, supplyId);
+
+        assertEquals(List.of(), result);
+        verifyNoInteractions(getPlantRepository);
+    }
+
+    @Test
     void getDailyProductionByRangeOfDatesAndSupply_throwsWhenSupplyNotFound() {
         SupplyId supplyId = SupplyId.of(UUID.randomUUID());
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.empty());
@@ -130,6 +162,22 @@ class GetProductionServiceTest {
 
         assertSame(expected, result);
         verify(getProductionRepository).getMonthlyProductionByRangeOfDates(startDate, endDate, 0.75f, stationCodes);
+    }
+
+    @Test
+    void getMonthlyProductionByRangeOfDatesAndSupply_supplyWithNoCommunityYieldsEmptyStationCodes() {
+        UUID supplyUuid = UUID.randomUUID();
+        SupplyId supplyId = SupplyId.of(supplyUuid);
+        Supply supply = SupplyMother.random().withId(supplyUuid).withCommunity(null).build();
+
+        when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
+        when(getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate,
+                supply.getPartitionCoefficient(), List.of())).thenReturn(List.of());
+
+        List<ProductionByTime> result = service.getMonthlyProductionByRangeOfDatesAndSupply(startDate, endDate, supplyId);
+
+        assertEquals(List.of(), result);
+        verifyNoInteractions(getPlantRepository);
     }
 
     @Test


### PR DESCRIPTION
# Fix per-supply production queries leaking across communities

## Summary

- `GetProductionServiceImpl`'s per-supply production methods (`GET /api/v1/supplies/{id}/production/hourly|daily|monthly`) called repository overloads with an empty InfluxQL station clause, which means **no restriction** — production was aggregated across every plant of every community, not just the requesting supply's own community. Invisible today with a single community/plant; would silently over-report the moment a second community/plant exists.
- Restricts the per-supply path to the supply's own community's plants (`supply → community → findPlantCodesByCommunity`), reusing the exact mechanism the community-scoped endpoints already use. This is a documented approximation (see the code comment on `resolveStationCodes`) until the `(plant_id, supply_id)` participation table lands in phase 2d/4 of the Sharing Agreements epic — resolving via `Plant.supply` instead would have zeroed out production for the (common) case of supplies that own no plant of their own.
- Removes the now-dead no-station-filter repository overloads and moves the "no station restriction ⇒ no query, empty result" invariant into the private InfluxQL builder methods, so it can't be bypassed by any future caller.
- Adds an integration test proving cross-community isolation — verified it fails on the pre-fix code (returned both communities' production instead of one) and passes after the fix.

## Commits

1. `fix: restrict per-supply production queries to the supply's own plants` — the behavior change, plus fixing the 3 tests that were only green because they encoded the buggy behavior as expected.
2. `refactor: remove production repository overloads with no station filter` — pure refactor, no behavior change.
3. `test: cross-community isolation of per-supply production` — new regression coverage.

## Out of scope

- The partition-coefficient (β) multiplier, still a scalar literal inside the InfluxQL string — separate, already-tracked problem (phase 4).
- The exact `(plant_id, supply_id)` participation table (phase 2d) — this fix is the documented approximation that holds until that lands.

## Test plan

- [x] `./gradlew test` — full suite green
- [x] `./gradlew build` — ArchUnit checks pass (no JPA/authorization boundary changes)
- [x] New `GetProductionServiceImplIntegrationTest` cross-community isolation test confirmed to **fail** on pre-fix code (checked out via a throwaway worktree) and pass after the fix
- [x] Empty station set (community with no plant) confirmed to yield an empty result, not an unrestricted query