### PR TITLE
Feature/conluz 202

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/UserExceptionHandler.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/UserExceptionHandler.java
@@ -6,6 +6,7 @@ import org.lucoenergia.conluz.domain.admin.user.create.DefaultAdminUserAlreadyIn
 import org.lucoenergia.conluz.domain.admin.user.platformadmin.LastPlatformAdminException;
 import org.lucoenergia.conluz.infrastructure.shared.error.ErrorBuilder;
 import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestErrorCode;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
@@ -67,6 +68,6 @@ public class UserExceptionHandler {
                 List.of().toArray(),
                 LocaleContextHolder.getLocale()
         );
-        return errorBuilder.build(message, HttpStatus.CONFLICT);
+        return errorBuilder.build(message, RestErrorCode.USER_LAST_PLATFORM_ADMIN, null, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/RevokePlatformAdminController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/RevokePlatformAdminController.java
@@ -3,6 +3,7 @@ package org.lucoenergia.conluz.infrastructure.admin.user.platformadmin;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -14,6 +15,7 @@ import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.Forbidd
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,13 +63,21 @@ public class RevokePlatformAdminController {
                     description = "The request conflicts with the current state: the last platform admin cannot be revoked.",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RestError.class),
                             examples = @ExampleObject(
                                     value = """
                                             {
                                                "timestamp": "2024-01-03T10:10:25.534035352+01:00",
                                                "status": 409,
                                                "message": "Cannot revoke the last platform administrator.",
-                                               "traceId": "6e602860-80f7-4802-b20f-8b53fb011013"
+                                               "traceId": "6e602860-80f7-4802-b20f-8b53fb011013",
+                                               "errors": [
+                                                 {
+                                                   "message": "Cannot revoke the last platform administrator.",
+                                                   "code": "USER_LAST_PLATFORM_ADMIN",
+                                                   "params": null
+                                                 }
+                                               ]
                                             }
                                             """
                             )

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/error/ErrorBuilder.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/error/ErrorBuilder.java
@@ -1,6 +1,8 @@
 package org.lucoenergia.conluz.infrastructure.shared.error;
 
 import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestErrorCode;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestErrorDetail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -9,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -59,5 +63,18 @@ public class ErrorBuilder {
         LOGGER.error("Error message: {}. Trace ID: {}.", message, traceId);
 
         return new ResponseEntity<>(new RestError(status.value(), message, traceId), status);
+    }
+
+    public ResponseEntity<RestError> build(String message, RestErrorCode code, Map<String, String> params,
+                                            HttpStatus status) {
+
+        final String traceId = UUID.randomUUID().toString();
+
+        LOGGER.error("Error message: {}. Trace ID: {}.", message, traceId);
+
+        final RestError restError = new RestError(status.value(), message, traceId,
+                List.of(new RestErrorDetail(message, code, params)));
+
+        return new ResponseEntity<>(restError, status);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/error/ErrorBuilder.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/error/ErrorBuilder.java
@@ -22,14 +22,14 @@ public class ErrorBuilder {
         this.messageSource = messageSource;
     }
 
-    public ResponseEntity<RestError> build(Throwable exception, String code, Object[] args, HttpStatus status) {
+    public ResponseEntity<RestError> build(Throwable exception, String messageKey, Object[] args, HttpStatus status) {
 
         final String traceId = UUID.randomUUID().toString();
 
         LOGGER.error("Error: {}. Trace ID: {}.", exception.getMessage(), traceId, exception);
 
         final String message = messageSource.getMessage(
-                code,
+                messageKey,
                 args,
                 LocaleContextHolder.getLocale()
         );
@@ -37,14 +37,14 @@ public class ErrorBuilder {
         return new ResponseEntity<>(new RestError(status.value(), message, traceId), status);
     }
 
-    public ResponseEntity<RestError> build(String exceptionMessage, String code, Object[] args, HttpStatus status) {
+    public ResponseEntity<RestError> build(String exceptionMessage, String messageKey, Object[] args, HttpStatus status) {
 
         final String traceId = UUID.randomUUID().toString();
 
         LOGGER.error("Error message: {}. Trace ID: {}.", exceptionMessage, traceId);
 
         final String message = messageSource.getMessage(
-                code,
+                messageKey,
                 args,
                 LocaleContextHolder.getLocale()
         );

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestError.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestError.java
@@ -1,20 +1,49 @@
 package org.lucoenergia.conluz.infrastructure.shared.web.error;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.OffsetDateTime;
+import java.util.List;
 
 public class RestError {
 
     private final OffsetDateTime timestamp;
     private final int status;
+
+    @Schema(description = "Human-readable summary. When there is exactly one error, equals " +
+            "errors[0].message. When there are several (e.g. a batch import with per-line " +
+            "errors), this is a short summary (e.g. \"The file contains 5 invalid lines\") - " +
+            "never a concatenation of the individual messages. Existing clients that only read " +
+            "`message` keep working; new clients should read `errors` for the full, structured " +
+            "list. This field exists for backward compatibility and as the fallback for " +
+            "clients that do not understand `code`.")
     private final String message;
+
     private final String traceId;
 
+    @Schema(description = "The individual errors that make up this response. Always has at " +
+            "least one element.", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final List<RestErrorDetail> errors;
+
+    /**
+     * Convenience constructor for the single-message case; derives {@code errors} from
+     * {@code message}.
+     */
     public RestError(int status, String message, String traceId) {
+        this(status, message, traceId, List.of(new RestErrorDetail(message, null, null)));
+    }
+
+    public RestError(int status, String message, String traceId, List<RestErrorDetail> errors) {
+        if (errors == null || errors.isEmpty()) {
+            throw new IllegalArgumentException("errors must not be null or empty");
+        }
+
         this.timestamp = OffsetDateTime.now();
         this.traceId = traceId;
 
         this.status = status;
         this.message = message;
+        this.errors = List.copyOf(errors);
     }
 
     public OffsetDateTime getTimestamp() {
@@ -31,5 +60,9 @@ public class RestError {
 
     public String getTraceId() {
         return traceId;
+    }
+
+    public List<RestErrorDetail> getErrors() {
+        return errors;
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorCode.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorCode.java
@@ -1,0 +1,22 @@
+package org.lucoenergia.conluz.infrastructure.shared.web.error;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Stable, machine-readable error codes for {@link RestErrorDetail#getCode()}.
+ *
+ * <p>A newer backend may emit a code that an already-deployed conluz-web does not know. The
+ * generated TypeScript union is a compile-time construct and offers no runtime protection.
+ * Clients must always have a default branch and fall back to rendering {@code message}.
+ * Adding a value here is additive and non-breaking; renaming or removing one is a breaking
+ * API change.
+ *
+ * <p>Naming: SCREAMING_SNAKE_CASE, namespaced by domain area (e.g. {@code USER_}, {@code
+ * SUPPLY_}). Values are paired with {@link RestErrorDetail#getParams()} keys in camelCase,
+ * used as i18n interpolation variables by clients.
+ */
+@Schema(description = "Stable machine-readable error code.")
+public enum RestErrorCode {
+
+    USER_LAST_PLATFORM_ADMIN
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorDetail.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorDetail.java
@@ -1,0 +1,45 @@
+package org.lucoenergia.conluz.infrastructure.shared.web.error;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+public class RestErrorDetail {
+
+    @Schema(description = "Human-readable error message, in English.",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String message;
+
+    @Schema(description = "Null for errors not yet migrated to the typed contract; clients " +
+            "must fall back to `message` for those.")
+    private final RestErrorCode code;
+
+    /**
+     * Carries structured data the client cannot already derive from the request it just sent
+     * (e.g. a line number in an uploaded file, the offending value, a computed sum). Never
+     * repeats an identifier the caller already supplied (e.g. a path variable) - that is noise,
+     * not data. Values use invariant formatting: no locale-specific number/date formatting (a
+     * BigDecimal keeps its scale, e.g. "0.998765"); localization is a conluz-web concern.
+     */
+    @Schema(description = "Structured data for this error, keyed in camelCase for use as i18n " +
+            "interpolation variables. Null when the error carries no such data.")
+    private final Map<String, String> params;
+
+    public RestErrorDetail(String message, RestErrorCode code, Map<String, String> params) {
+        this.message = message;
+        this.code = code;
+        this.params = params;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public RestErrorCode getCode() {
+        return code;
+    }
+
+    public Map<String, String> getParams() {
+        return params;
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/RevokePlatformAdminControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/RevokePlatformAdminControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.lucoenergia.conluz.domain.admin.user.DefaultUserAdminMother.PERSONAL_ID;
 import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -76,7 +77,10 @@ class RevokePlatformAdminControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()))
-                .andExpect(jsonPath("$.message").isNotEmpty());
+                .andExpect(jsonPath("$.message").isNotEmpty())
+                .andExpect(jsonPath("$.errors[0].code").value("USER_LAST_PLATFORM_ADMIN"))
+                .andExpect(jsonPath("$.errors[0].params").value(nullValue()))
+                .andExpect(jsonPath("$.errors[0].message").isNotEmpty());
 
         // The default platform admin still holds the flag.
         Assertions.assertTrue(getUserRepository.findByPersonalId(UserPersonalId.of(PERSONAL_ID))
@@ -117,7 +121,11 @@ class RevokePlatformAdminControllerTest extends BaseControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                // Backward compatibility: an unmigrated error still carries a matching scalar
+                // `message` and a null `code`, proving the additive contract doesn't break it.
+                .andExpect(jsonPath("$.errors[0].code").value(nullValue()))
+                .andExpect(jsonPath("$.errors[0].message").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorDetailTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorDetailTest.java
@@ -1,0 +1,45 @@
+package org.lucoenergia.conluz.infrastructure.shared.web.error;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RestErrorDetailTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesParamsAsFlatStringMap() throws Exception {
+
+        RestErrorDetail detail = new RestErrorDetail("The file contains an invalid line",
+                RestErrorCode.USER_LAST_PLATFORM_ADMIN, Map.of("lineNumber", "5", "value", "abc"));
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(detail));
+
+        assertEquals("The file contains an invalid line", json.get("message").asText());
+        assertEquals("USER_LAST_PLATFORM_ADMIN", json.get("code").asText());
+
+        JsonNode params = json.get("params");
+        assertTrue(params.isObject());
+        assertEquals("5", params.get("lineNumber").asText());
+        assertEquals("abc", params.get("value").asText());
+        assertTrue(params.get("lineNumber").isTextual());
+    }
+
+    @Test
+    void serializesNullCodeAndParamsAsExplicitNulls() throws Exception {
+
+        RestErrorDetail detail = new RestErrorDetail("Something went wrong", null, null);
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(detail));
+
+        assertEquals("Something went wrong", json.get("message").asText());
+        assertTrue(json.get("code").isNull());
+        assertTrue(json.get("params").isNull());
+    }
+}


### PR DESCRIPTION
## Title
`[conluz-202] Add typed error code and params to the REST error contract (phase 1)`

## Summary

- Adds a stable, machine-readable `code` (enum) and structured `params` (`Map<String,String>`) to every REST error, alongside the existing human-readable `message` — an enabler for phase 3 (distributor file import), which needs to return per-line validation errors that `conluz-web` can render without string-matching `message`.
- `RestError` gains a non-null, non-empty `errors: List<RestErrorDetail>` field so a single response can eventually carry N errors, not just one. The invariant (`errors` never null/empty) is enforced in `RestError`'s own constructor, not left to caller convention — a convenience 3-arg constructor derives a single-element list from `message`, so every one of the ~43 existing `ErrorBuilder`/handler call sites is untouched and keeps emitting `code: null` / `params: null`.
- Migrates exactly one exemplar end-to-end — `LastPlatformAdminException` (409) — chosen because it's the only error `conluz-web` already consumes dynamically today (`UsersPage.tsx` reads `response.data.message` on this exact revoke-admin call instead of a hardcoded string). No sharing-agreement codes, no mass migration of other handlers, no DB/Liquibase change.
- Discovered along the way: no error response in this codebase was ever wired to a real OpenAPI schema (`schema = @Schema(implementation = ...)`) — only hand-written `@ExampleObject` strings — so `RestError` never reached `components/schemas` for any endpoint. Fixed this on the exemplar's `@ApiResponse` so `code`/`params` actually reach Orval; left the other four shared error-response annotations (`@BadRequestErrorResponse` etc.) as-is, out of scope for this phase.

## Details

- `RestErrorCode` (new enum, `infrastructure/shared/web/error`): `USER_LAST_PLATFORM_ADMIN` is the only value today. Javadoc documents that adding values is additive/non-breaking, renaming/removing one is breaking, and clients must always fall back to `message`.
- `RestErrorDetail` (new DTO): `message` (mandatory), `code` (nullable), `params` (nullable). `params` Javadoc states the rule: only data the client can't already derive from its own request — never an identifier it just sent.
- `ErrorBuilder`: renamed the pre-existing `code` param (an i18n `MessageSource` key, unrelated concept) to `messageKey` in its own commit to avoid confusion with the new `RestErrorCode`; added one new overload for typed errors, existing three untouched.
- `RestError.message`'s `@Schema` documents what it means once `errors` has N elements (a summary, never a concatenation) — for phase 3 to follow.

## Verified via generated `/api-docs`

```json
"RestError": {
  "properties": { "errors": { "type": "array", "items": { "$ref": "#/components/schemas/RestErrorDetail" } } },
  "required": ["errors"]
}
"RestErrorDetail": {
  "properties": {
    "message": { "type": "string" },
    "code": { "type": "string", "enum": ["USER_LAST_PLATFORM_ADMIN"] },
    "params": { "type": "object", "additionalProperties": { "type": "string" } }
  },
  "required": ["message"]
}
```

## Test plan

- [x] `./gradlew test` — full suite green, including all 5 ArchUnit tests
- [x] `RestErrorDetailTest` — Jackson serialization: populated `params` serializes as a flat string map; null `code`/`params` serialize as explicit `null`
- [x] `RevokePlatformAdminControllerTest` — asserts serialized JSON body for the migrated 409 (`errors[0].code == USER_LAST_PLATFORM_ADMIN`, `params == null`) and for the unmigrated 404 (`errors[0].code == null`, `message` unchanged), as direct evidence of backward compatibility
- [x] Manually inspected generated `/api-docs` schema fragment (above)