### PR TITLE
[conluz-204] Rename plant code to provider code

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/production/get/GetEnergyStationRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/get/GetEnergyStationRepository.java
@@ -13,7 +13,7 @@ public interface GetEnergyStationRepository {
 
     List<Plant> findAllByInverterProvider(InverterProvider provider);
 
-    Optional<Plant> findByCode(String code);
+    Optional<Plant> findByProviderCode(String providerCode);
 
     Optional<Plant> findById(UUID plantId);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/huawei/aggregate/HuaweiProductionMonthlyAggregationService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/huawei/aggregate/HuaweiProductionMonthlyAggregationService.java
@@ -28,7 +28,7 @@ public interface HuaweiProductionMonthlyAggregationService {
      * Aggregates a single plant, requiring it to belong to the given community so a job for one
      * community cannot aggregate another community's plant.
      */
-    void aggregateMonthlyProductions(UUID communityId, String plantCode, Month month, int year);
+    void aggregateMonthlyProductions(UUID communityId, String plantProviderCode, Month month, int year);
 
     /**
      * Entry point for the manual community sync endpoint. Verifies that Huawei is enabled and then
@@ -37,9 +37,9 @@ public interface HuaweiProductionMonthlyAggregationService {
      * controller does not embed domain logic.
      *
      * @param communityId the community whose plants are aggregated
-     * @param plantCode   optional plant code; when null/blank, all the community's plants are aggregated
+     * @param plantProviderCode   optional plant code; when null/blank, all the community's plants are aggregated
      * @param month       optional month (1-12); when null, every month of the year is aggregated
      * @param year        the year to aggregate
      */
-    void syncMonthlyProductions(UUID communityId, String plantCode, Integer month, int year);
+    void syncMonthlyProductions(UUID communityId, String plantProviderCode, Integer month, int year);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/huawei/aggregate/HuaweiProductionYearlyAggregationService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/huawei/aggregate/HuaweiProductionYearlyAggregationService.java
@@ -24,7 +24,7 @@ public interface HuaweiProductionYearlyAggregationService {
      * Aggregates a single plant, requiring it to belong to the given community so a job for one
      * community cannot aggregate another community's plant.
      */
-    void aggregateYearlyProductions(UUID communityId, String plantCode, int year);
+    void aggregateYearlyProductions(UUID communityId, String plantProviderCode, int year);
 
     /**
      * Entry point for the manual community sync endpoint. Verifies that Huawei is enabled and then
@@ -33,8 +33,8 @@ public interface HuaweiProductionYearlyAggregationService {
      * embed domain logic.
      *
      * @param communityId the community whose plants are aggregated
-     * @param plantCode   optional plant code; when null/blank, all the community's plants are aggregated
+     * @param plantProviderCode   optional plant code; when null/blank, all the community's plants are aggregated
      * @param year        the year to aggregate
      */
-    void syncYearlyProductions(UUID communityId, String plantCode, int year);
+    void syncYearlyProductions(UUID communityId, String plantProviderCode, int year);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/Plant.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/Plant.java
@@ -17,8 +17,14 @@ public class Plant {
     private UUID id;
     @NotBlank
     private String name;
+    /**
+     * The plant identifier assigned by the inverter provider (currently Huawei). Used verbatim as
+     * the {@code station_code} tag in InfluxDB: this is the join key between the PostgreSQL plant
+     * row and its time series. It is not a CUPS and not a CAU -- the regulator's code is
+     * {@code regulatory_code}.
+     */
     @NotBlank
-    private String code;
+    private String providerCode;
     @NotBlank
     private String address;
     @NotBlank
@@ -42,8 +48,8 @@ public class Plant {
         return name;
     }
 
-    public String getCode() {
-        return code;
+    public String getProviderCode() {
+        return providerCode;
     }
 
     public String getAddress() {
@@ -81,7 +87,7 @@ public class Plant {
     public static class Builder {
         private UUID id;
         private String name;
-        private String code;
+        private String providerCode;
         private String address;
         private String description;
         private InverterProvider inverterProvider;
@@ -99,8 +105,8 @@ public class Plant {
             return this;
         }
 
-        public Builder withCode(String code) {
-            this.code = code;
+        public Builder withProviderCode(String providerCode) {
+            this.providerCode = providerCode;
             return this;
         }
 
@@ -138,7 +144,7 @@ public class Plant {
             Plant station = new Plant();
             station.id = this.id;
             station.name = this.name;
-            station.code = this.code;
+            station.providerCode = this.providerCode;
             station.address = this.address;
             station.description = this.description;
             station.inverterProvider = this.inverterProvider;
@@ -153,19 +159,19 @@ public class Plant {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Plant plant)) return false;
-        return Objects.equals(getId(), plant.getId()) && Objects.equals(getName(), plant.getName()) && Objects.equals(getCode(), plant.getCode());
+        return Objects.equals(getId(), plant.getId()) && Objects.equals(getName(), plant.getName()) && Objects.equals(getProviderCode(), plant.getProviderCode());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getName(), getCode());
+        return Objects.hash(getId(), getName(), getProviderCode());
     }
 
     @Override
     public String toString() {
         return "Plant{" +
                 "name='" + name + '\'' +
-                ", code='" + code + '\'' +
+                ", providerCode='" + providerCode + '\'' +
                 ", id=" + id +
                 '}';
     }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/PlantAlreadyExistsException.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/PlantAlreadyExistsException.java
@@ -1,16 +1,16 @@
 package org.lucoenergia.conluz.domain.production.plant;
 
-import org.lucoenergia.conluz.domain.shared.PlantCode;
+import org.lucoenergia.conluz.domain.shared.PlantProviderCode;
 
 public class PlantAlreadyExistsException extends RuntimeException {
 
-    private final PlantCode code;
+    private final PlantProviderCode providerCode;
 
-    public PlantAlreadyExistsException(PlantCode code) {
-        this.code = code;
+    public PlantAlreadyExistsException(PlantProviderCode providerCode) {
+        this.providerCode = providerCode;
     }
 
-    public PlantCode getCode() {
-        return code;
+    public PlantProviderCode getProviderCode() {
+        return providerCode;
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/PlantNotFoundException.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/PlantNotFoundException.java
@@ -5,21 +5,21 @@ import org.lucoenergia.conluz.domain.shared.PlantId;
 public class PlantNotFoundException extends RuntimeException {
 
     private PlantId id;
-    private String code;
+    private String providerCode;
 
     public PlantNotFoundException(PlantId id) {
         this.id = id;
     }
 
-    public PlantNotFoundException(String code) {
-        this.code = code;
+    public PlantNotFoundException(String providerCode) {
+        this.providerCode = providerCode;
     }
 
     public PlantId getId() {
         return id;
     }
 
-    public String getCode() {
-        return code;
+    public String getProviderCode() {
+        return providerCode;
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/get/GetPlantRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/get/GetPlantRepository.java
@@ -22,10 +22,10 @@ public interface GetPlantRepository {
     PagedResult<Plant> findByCommunities(PagedRequest pagedRequest, Set<UUID> communityIds);
 
     /**
-     * Codes of the plants belonging to the given community. These codes match the InfluxDB
+     * Provider codes of the plants belonging to the given community. These codes match the InfluxDB
      * {@code station_code} tag, so they can be used to scope time-series production queries.
      */
-    List<String> findPlantCodesByCommunity(UUID communityId);
+    List<String> findPlantProviderCodesByCommunity(UUID communityId);
 
     /**
      * Supply codes (CUPS) of the plants belonging to the given community. Used to detect which

--- a/src/main/java/org/lucoenergia/conluz/domain/shared/PlantProviderCode.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/shared/PlantProviderCode.java
@@ -1,15 +1,15 @@
 package org.lucoenergia.conluz.domain.shared;
 
-public class PlantCode {
+public class PlantProviderCode {
 
     private final String code;
 
-    public PlantCode(String code) {
+    public PlantProviderCode(String code) {
         this.code = code;
     }
 
-    public static PlantCode of(String code) {
-        return new PlantCode(code);
+    public static PlantProviderCode of(String code) {
+        return new PlantProviderCode(code);
     }
 
     public String getCode() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetEnergyStationRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetEnergyStationRepositoryDatabase.java
@@ -39,8 +39,8 @@ public class GetEnergyStationRepositoryDatabase implements GetEnergyStationRepos
     }
 
     @Override
-    public Optional<Plant> findByCode(String code) {
-        return plantRepository.findByCode(code).map(this::mapEntityToDomain);
+    public Optional<Plant> findByProviderCode(String providerCode) {
+        return plantRepository.findByProviderCode(providerCode).map(this::mapEntityToDomain);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class GetEnergyStationRepositoryDatabase implements GetEnergyStationRepos
         return new Plant.Builder()
                 .withId(entity.getId())
                 .withName(entity.getName())
-                .withCode(entity.getCode())
+                .withProviderCode(entity.getProviderCode())
                 .withAddress(entity.getAddress())
                 .withDescription(entity.getDescription())
                 .withInverterProvider(entity.getInverterProvider())

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImpl.java
@@ -73,14 +73,14 @@ public class GetProductionServiceImpl implements GetProductionService {
 
     @Override
     public InstantProduction getInstantProductionByCommunity(UUID communityId) {
-        return getProductionRepository.getInstantProduction(getPlantRepository.findPlantCodesByCommunity(communityId));
+        return getProductionRepository.getInstantProduction(getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
     public InstantProduction getInstantProductionByCommunityAndSupply(UUID communityId, SupplyId id) {
         Supply supply = requireSupplyInCommunity(id, communityId);
         InstantProduction total = getProductionRepository.getInstantProduction(
-                getPlantRepository.findPlantCodesByCommunity(communityId));
+                getPlantRepository.findPlantProviderCodesByCommunity(communityId));
         return new InstantProduction(total.getPower() * supply.getPartitionCoefficient());
     }
 
@@ -88,7 +88,7 @@ public class GetProductionServiceImpl implements GetProductionService {
     public List<ProductionByTime> getHourlyProductionByRangeOfDatesAndCommunity(OffsetDateTime startDate,
                                                                                 OffsetDateTime endDate, UUID communityId) {
         return getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate, 1f,
-                getPlantRepository.findPlantCodesByCommunity(communityId));
+                getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
@@ -97,14 +97,14 @@ public class GetProductionServiceImpl implements GetProductionService {
                                                                                          UUID communityId, SupplyId id) {
         Supply supply = requireSupplyInCommunity(id, communityId);
         return getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate,
-                supply.getPartitionCoefficient(), getPlantRepository.findPlantCodesByCommunity(communityId));
+                supply.getPartitionCoefficient(), getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
     public List<ProductionByTime> getDailyProductionByRangeOfDatesAndCommunity(OffsetDateTime startDate,
                                                                                OffsetDateTime endDate, UUID communityId) {
         return getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate, 1f,
-                getPlantRepository.findPlantCodesByCommunity(communityId));
+                getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
@@ -113,14 +113,14 @@ public class GetProductionServiceImpl implements GetProductionService {
                                                                                         UUID communityId, SupplyId id) {
         Supply supply = requireSupplyInCommunity(id, communityId);
         return getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate,
-                supply.getPartitionCoefficient(), getPlantRepository.findPlantCodesByCommunity(communityId));
+                supply.getPartitionCoefficient(), getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
     public List<ProductionByTime> getMonthlyProductionByRangeOfDatesAndCommunity(OffsetDateTime startDate,
                                                                                  OffsetDateTime endDate, UUID communityId) {
         return getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate, 1f,
-                getPlantRepository.findPlantCodesByCommunity(communityId));
+                getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
@@ -129,14 +129,14 @@ public class GetProductionServiceImpl implements GetProductionService {
                                                                                           UUID communityId, SupplyId id) {
         Supply supply = requireSupplyInCommunity(id, communityId);
         return getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate,
-                supply.getPartitionCoefficient(), getPlantRepository.findPlantCodesByCommunity(communityId));
+                supply.getPartitionCoefficient(), getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
     public List<ProductionByTime> getYearlyProductionByRangeOfDatesAndCommunity(OffsetDateTime startDate,
                                                                                 OffsetDateTime endDate, UUID communityId) {
         return getProductionRepository.getYearlyProductionByRangeOfDates(startDate, endDate, 1f,
-                getPlantRepository.findPlantCodesByCommunity(communityId));
+                getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     @Override
@@ -145,7 +145,7 @@ public class GetProductionServiceImpl implements GetProductionService {
                                                                                          UUID communityId, SupplyId id) {
         Supply supply = requireSupplyInCommunity(id, communityId);
         return getProductionRepository.getYearlyProductionByRangeOfDates(startDate, endDate,
-                supply.getPartitionCoefficient(), getPlantRepository.findPlantCodesByCommunity(communityId));
+                supply.getPartitionCoefficient(), getPlantRepository.findPlantProviderCodesByCommunity(communityId));
     }
 
     /**
@@ -161,7 +161,7 @@ public class GetProductionServiceImpl implements GetProductionService {
         if (supply.getCommunity() == null) {
             return List.of();
         }
-        return getPlantRepository.findPlantCodesByCommunity(supply.getCommunity().getId());
+        return getPlantRepository.findPlantProviderCodesByCommunity(supply.getCommunity().getId());
     }
 
     /**

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationRepositoryInflux.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationRepositoryInflux.java
@@ -40,7 +40,7 @@ public class HuaweiProductionMonthlyAggregationRepositoryInflux implements Huawe
     public void aggregateMonthlyProduction(Plant plant, Month month, int year) {
 
         LOGGER.info("Aggregating monthly production for plant: {}, month: {}, year: {}",
-                plant.getCode(), month, year);
+                plant.getProviderCode(), month, year);
 
         final String startDate = dateConverter.convertToFirstDayOfTheMonthAsString(month, year);
         final String endDate = dateConverter.convertToLastDayOfTheMonthAsString(month, year);
@@ -62,7 +62,7 @@ public class HuaweiProductionMonthlyAggregationRepositoryInflux implements Huawe
                     GROUP BY station_code
                     """,
                     HuaweiConfig.HUAWEI_HOURLY_PRODUCTION_MEASUREMENT,
-                    plant.getCode(),
+                    plant.getProviderCode(),
                     startDate,
                     endDate));
 
@@ -78,7 +78,7 @@ public class HuaweiProductionMonthlyAggregationRepositoryInflux implements Huawe
 
             if (aggregatedData.isEmpty()) {
                 LOGGER.warn("No hourly data found to aggregate for plant: {}, month: {}, year: {}",
-                        plant.getCode(), month, year);
+                        plant.getProviderCode(), month, year);
                 return;
             }
 
@@ -92,7 +92,7 @@ public class HuaweiProductionMonthlyAggregationRepositoryInflux implements Huawe
 
             Point point = Point.measurement(HuaweiConfig.HUAWEI_MONTHLY_PRODUCTION_MEASUREMENT)
                     .time(timestamp, TimeUnit.MILLISECONDS)
-                    .tag("station_code", plant.getCode())
+                    .tag("station_code", plant.getProviderCode())
                     .addField("inverter_power", aggregated.getInverterPower() != null ? aggregated.getInverterPower() : 0.0)
                     .addField("ongrid_power", aggregated.getOngridPower() != null ? aggregated.getOngridPower() : 0.0)
                     .addField("power_profit", aggregated.getPowerProfit() != null ? aggregated.getPowerProfit() : 0.0)
@@ -104,7 +104,7 @@ public class HuaweiProductionMonthlyAggregationRepositoryInflux implements Huawe
             connection.write(batchPoints);
 
             LOGGER.info("Successfully aggregated monthly production for plant: {}, month: {}, year: {}",
-                    plant.getCode(), month, year);
+                    plant.getProviderCode(), month, year);
         }
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationServiceImpl.java
@@ -73,27 +73,27 @@ public class HuaweiProductionMonthlyAggregationServiceImpl implements HuaweiProd
     }
 
     @Override
-    public void aggregateMonthlyProductions(UUID communityId, String plantCode, Month month, int year) {
-        Plant plant = getEnergyStationRepository.findByCode(plantCode)
-                .orElseThrow(() -> new PlantNotFoundException(plantCode));
-        if (!getPlantRepository.findPlantCodesByCommunity(communityId).contains(plantCode)) {
-            throw new PlantNotFoundException(plantCode);
+    public void aggregateMonthlyProductions(UUID communityId, String plantProviderCode, Month month, int year) {
+        Plant plant = getEnergyStationRepository.findByProviderCode(plantProviderCode)
+                .orElseThrow(() -> new PlantNotFoundException(plantProviderCode));
+        if (!getPlantRepository.findPlantProviderCodesByCommunity(communityId).contains(plantProviderCode)) {
+            throw new PlantNotFoundException(plantProviderCode);
         }
         aggregateForPlantMonthYear(plant, month, year);
     }
 
     @Override
-    public void syncMonthlyProductions(UUID communityId, String plantCode, Integer month, int year) {
+    public void syncMonthlyProductions(UUID communityId, String plantProviderCode, Integer month, int year) {
         if (getHuaweiConfigRepository.getEnabledHuaweiConfigs().isEmpty()) {
             throw new HuaweiDisabledException();
         }
 
-        if (plantCode != null && !plantCode.isBlank()) {
+        if (plantProviderCode != null && !plantProviderCode.isBlank()) {
             if (month != null) {
-                aggregateMonthlyProductions(communityId, plantCode, Month.of(month), year);
+                aggregateMonthlyProductions(communityId, plantProviderCode, Month.of(month), year);
             } else {
                 for (Month everyMonth : Month.values()) {
-                    aggregateMonthlyProductions(communityId, plantCode, everyMonth, year);
+                    aggregateMonthlyProductions(communityId, plantProviderCode, everyMonth, year);
                 }
             }
         } else {
@@ -109,8 +109,8 @@ public class HuaweiProductionMonthlyAggregationServiceImpl implements HuaweiProd
      * Resolves the plants belonging to the given community from their codes.
      */
     private List<Plant> communityPlants(UUID communityId) {
-        return getPlantRepository.findPlantCodesByCommunity(communityId).stream()
-                .map(getEnergyStationRepository::findByCode)
+        return getPlantRepository.findPlantProviderCodesByCommunity(communityId).stream()
+                .map(getEnergyStationRepository::findByProviderCode)
                 .flatMap(Optional::stream)
                 .toList();
     }
@@ -120,7 +120,7 @@ public class HuaweiProductionMonthlyAggregationServiceImpl implements HuaweiProd
             aggregationRepository.aggregateMonthlyProduction(plant, month, year);
         } catch (Exception e) {
             LOGGER.error("Failed to aggregate monthly production for plant: {}, month: {}, year: {}",
-                    plant.getCode(), month, year, e);
+                    plant.getProviderCode(), month, year, e);
         }
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationRepositoryInflux.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationRepositoryInflux.java
@@ -38,7 +38,7 @@ public class HuaweiProductionYearlyAggregationRepositoryInflux implements Huawei
     @Override
     public void aggregateYearlyProduction(Plant plant, int year) {
 
-        LOGGER.info("Aggregating yearly production for plant: {}, year: {}", plant.getCode(), year);
+        LOGGER.info("Aggregating yearly production for plant: {}, year: {}", plant.getProviderCode(), year);
 
         String startDate = String.format("%d-01-01T00:00:00Z", year);
         String endDate = String.format("%d-12-31T23:59:59Z", year);
@@ -60,7 +60,7 @@ public class HuaweiProductionYearlyAggregationRepositoryInflux implements Huawei
                     GROUP BY station_code
                     """,
                     HuaweiConfig.HUAWEI_MONTHLY_PRODUCTION_MEASUREMENT,
-                    plant.getCode(),
+                    plant.getProviderCode(),
                     startDate,
                     endDate));
 
@@ -75,7 +75,7 @@ public class HuaweiProductionYearlyAggregationRepositoryInflux implements Huawei
             List<HuaweiHourlyProductionMonthlyPoint> aggregatedData = resultMapper.toPOJO(queryResult, HuaweiHourlyProductionMonthlyPoint.class);
 
             if (aggregatedData.isEmpty()) {
-                LOGGER.warn("No monthly data found to aggregate for plant: {}, year: {}", plant.getCode(), year);
+                LOGGER.warn("No monthly data found to aggregate for plant: {}, year: {}", plant.getProviderCode(), year);
                 return;
             }
 
@@ -89,7 +89,7 @@ public class HuaweiProductionYearlyAggregationRepositoryInflux implements Huawei
 
             Point point = Point.measurement(HuaweiConfig.HUAWEI_YEARLY_PRODUCTION_MEASUREMENT)
                     .time(timestamp, TimeUnit.MILLISECONDS)
-                    .tag("station_code", plant.getCode())
+                    .tag("station_code", plant.getProviderCode())
                     .addField("inverter_power", aggregated.getInverterPower() != null ? aggregated.getInverterPower() : 0.0)
                     .addField("ongrid_power", aggregated.getOngridPower() != null ? aggregated.getOngridPower() : 0.0)
                     .addField("power_profit", aggregated.getPowerProfit() != null ? aggregated.getPowerProfit() : 0.0)
@@ -100,7 +100,7 @@ public class HuaweiProductionYearlyAggregationRepositoryInflux implements Huawei
             batchPoints.point(point);
             connection.write(batchPoints);
 
-            LOGGER.info("Successfully aggregated yearly production for plant: {}, year: {}", plant.getCode(), year);
+            LOGGER.info("Successfully aggregated yearly production for plant: {}, year: {}", plant.getProviderCode(), year);
         }
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationServiceImpl.java
@@ -63,23 +63,23 @@ public class HuaweiProductionYearlyAggregationServiceImpl implements HuaweiProdu
     }
 
     @Override
-    public void aggregateYearlyProductions(UUID communityId, String plantCode, int year) {
-        Plant plant = getEnergyStationRepository.findByCode(plantCode)
-                .orElseThrow(() -> new PlantNotFoundException(plantCode));
-        if (!getPlantRepository.findPlantCodesByCommunity(communityId).contains(plantCode)) {
-            throw new PlantNotFoundException(plantCode);
+    public void aggregateYearlyProductions(UUID communityId, String plantProviderCode, int year) {
+        Plant plant = getEnergyStationRepository.findByProviderCode(plantProviderCode)
+                .orElseThrow(() -> new PlantNotFoundException(plantProviderCode));
+        if (!getPlantRepository.findPlantProviderCodesByCommunity(communityId).contains(plantProviderCode)) {
+            throw new PlantNotFoundException(plantProviderCode);
         }
         aggregateForPlantYear(plant, year);
     }
 
     @Override
-    public void syncYearlyProductions(UUID communityId, String plantCode, int year) {
+    public void syncYearlyProductions(UUID communityId, String plantProviderCode, int year) {
         if (getHuaweiConfigRepository.getEnabledHuaweiConfigs().isEmpty()) {
             throw new HuaweiDisabledException();
         }
 
-        if (plantCode != null && !plantCode.isBlank()) {
-            aggregateYearlyProductions(communityId, plantCode, year);
+        if (plantProviderCode != null && !plantProviderCode.isBlank()) {
+            aggregateYearlyProductions(communityId, plantProviderCode, year);
         } else {
             aggregateYearlyProductions(communityId, year);
         }
@@ -89,8 +89,8 @@ public class HuaweiProductionYearlyAggregationServiceImpl implements HuaweiProdu
      * Resolves the plants belonging to the given community from their codes.
      */
     private List<Plant> communityPlants(UUID communityId) {
-        return getPlantRepository.findPlantCodesByCommunity(communityId).stream()
-                .map(getEnergyStationRepository::findByCode)
+        return getPlantRepository.findPlantProviderCodesByCommunity(communityId).stream()
+                .map(getEnergyStationRepository::findByProviderCode)
                 .flatMap(Optional::stream)
                 .toList();
     }
@@ -100,7 +100,7 @@ public class HuaweiProductionYearlyAggregationServiceImpl implements HuaweiProdu
             aggregationRepository.aggregateYearlyProduction(plant, year);
         } catch (Exception e) {
             LOGGER.error("Failed to aggregate yearly production for plant: {}, year: {}",
-                    plant.getCode(), year, e);
+                    plant.getProviderCode(), year, e);
         }
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/get/GetHuaweiHourlyProductionRepositoryRest.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/get/GetHuaweiHourlyProductionRepositoryRest.java
@@ -76,7 +76,7 @@ public class GetHuaweiHourlyProductionRepositoryRest {
         }
 
         String stationCodes = stations.stream()
-                .map(Plant::getCode)
+                .map(Plant::getProviderCode)
                 .collect(Collectors.joining(", "));
 
         final OkHttpClient client = conluzRestClientBuilder.build();

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/get/GetHuaweiRealTimeProductionRepositoryRest.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/get/GetHuaweiRealTimeProductionRepositoryRest.java
@@ -67,7 +67,7 @@ public class GetHuaweiRealTimeProductionRepositoryRest {
         }
 
         String stationCodes = stations.stream()
-                .map(Plant::getCode)
+                .map(Plant::getProviderCode)
                 .collect(Collectors.joining(", "));
 
         final OkHttpClient client = conluzRestClientBuilder.build();

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncMonthlyHuaweiProductionBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncMonthlyHuaweiProductionBody.java
@@ -17,7 +17,7 @@ public class SyncMonthlyHuaweiProductionBody {
     @Max(value = 12)
     private Integer month;
 
-    private String plantCode;
+    private String plantProviderCode;
 
     public SyncMonthlyHuaweiProductionBody() {
     }
@@ -31,10 +31,10 @@ public class SyncMonthlyHuaweiProductionBody {
         this.month = month;
     }
 
-    public SyncMonthlyHuaweiProductionBody(Integer year, Integer month, String plantCode) {
+    public SyncMonthlyHuaweiProductionBody(Integer year, Integer month, String plantProviderCode) {
         this.year = year;
         this.month = month;
-        this.plantCode = plantCode;
+        this.plantProviderCode = plantProviderCode;
     }
 
     public Integer getYear() {
@@ -53,11 +53,11 @@ public class SyncMonthlyHuaweiProductionBody {
         this.month = month;
     }
 
-    public String getPlantCode() {
-        return plantCode;
+    public String getPlantProviderCode() {
+        return plantProviderCode;
     }
 
-    public void setPlantCode(String plantCode) {
-        this.plantCode = plantCode;
+    public void setPlantProviderCode(String plantProviderCode) {
+        this.plantProviderCode = plantProviderCode;
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncMonthlyHuaweiProductionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncMonthlyHuaweiProductionController.java
@@ -42,13 +42,13 @@ public class SyncMonthlyHuaweiProductionController {
                     The request body must contain:
                     - **year** (required, integer): The year for which to aggregate data
                     - **month** (optional, integer 1-12): The month to aggregate. If not provided, all months of the year will be aggregated.
-                    - **plantCode** (optional, string): The plant code to aggregate. If not provided, all plants will be aggregated.
+                    - **plantProviderCode** (optional, string): The plant code to aggregate. If not provided, all plants will be aggregated.
 
                     **Behavior:**
-                    - If both month and plantCode are provided: Aggregates only that specific plant for that month
+                    - If both month and plantProviderCode are provided: Aggregates only that specific plant for that month
                     - If only month is provided: Aggregates all plants for that specific month
-                    - If only plantCode is provided: Aggregates that plant for all months of the year
-                    - If neither month nor plantCode is provided: Aggregates all plants for all months of the year
+                    - If only plantProviderCode is provided: Aggregates that plant for all months of the year
+                    - If neither month nor plantProviderCode is provided: Aggregates all plants for all months of the year
 
                     The community is taken from the path and only that community's plants are aggregated.
 
@@ -77,6 +77,6 @@ public class SyncMonthlyHuaweiProductionController {
     @PreAuthorize("@communityAccessGuard.canManageCommunity(#communityId)")
     public void syncMonthlyHuaweiProduction(@PathVariable UUID communityId,
                                             @Valid @RequestBody SyncMonthlyHuaweiProductionBody body) {
-        aggregationService.syncMonthlyProductions(communityId, body.getPlantCode(), body.getMonth(), body.getYear());
+        aggregationService.syncMonthlyProductions(communityId, body.getPlantProviderCode(), body.getMonth(), body.getYear());
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncYearlyHuaweiProductionBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncYearlyHuaweiProductionBody.java
@@ -13,7 +13,7 @@ public class SyncYearlyHuaweiProductionBody {
     @Max(value = 2100)
     private Integer year;
 
-    private String plantCode;
+    private String plantProviderCode;
 
     public SyncYearlyHuaweiProductionBody() {
     }
@@ -22,9 +22,9 @@ public class SyncYearlyHuaweiProductionBody {
         this.year = year;
     }
 
-    public SyncYearlyHuaweiProductionBody(Integer year, String plantCode) {
+    public SyncYearlyHuaweiProductionBody(Integer year, String plantProviderCode) {
         this.year = year;
-        this.plantCode = plantCode;
+        this.plantProviderCode = plantProviderCode;
     }
 
     public Integer getYear() {
@@ -35,11 +35,11 @@ public class SyncYearlyHuaweiProductionBody {
         this.year = year;
     }
 
-    public String getPlantCode() {
-        return plantCode;
+    public String getPlantProviderCode() {
+        return plantProviderCode;
     }
 
-    public void setPlantCode(String plantCode) {
-        this.plantCode = plantCode;
+    public void setPlantProviderCode(String plantProviderCode) {
+        this.plantProviderCode = plantProviderCode;
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncYearlyHuaweiProductionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/huawei/sync/SyncYearlyHuaweiProductionController.java
@@ -41,11 +41,11 @@ public class SyncYearlyHuaweiProductionController {
 
                     The request body must contain:
                     - **year** (required, integer): The year for which to aggregate data
-                    - **plantCode** (optional, string): The plant code to aggregate. If not provided, all plants will be aggregated.
+                    - **plantProviderCode** (optional, string): The plant code to aggregate. If not provided, all plants will be aggregated.
 
                     **Behavior:**
-                    - If plantCode is provided: Aggregates only that specific plant
-                    - If plantCode is not provided or is empty: Aggregates all plants
+                    - If plantProviderCode is provided: Aggregates only that specific plant
+                    - If plantProviderCode is not provided or is empty: Aggregates all plants
 
                     **Note:** This aggregation requires that monthly aggregations have already been performed
                     for the specified year.
@@ -77,6 +77,6 @@ public class SyncYearlyHuaweiProductionController {
     @PreAuthorize("@communityAccessGuard.canManageCommunity(#communityId)")
     public void syncYearlyHuaweiProduction(@PathVariable UUID communityId,
                                            @Valid @RequestBody SyncYearlyHuaweiProductionBody body) {
-        aggregationService.syncYearlyProductions(communityId, body.getPlantCode(), body.getYear());
+        aggregationService.syncYearlyProductions(communityId, body.getPlantProviderCode(), body.getYear());
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantEntity.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantEntity.java
@@ -14,7 +14,14 @@ public class PlantEntity {
     @Id
     private UUID id;
     private String name;
-    private String code;
+    /**
+     * The plant identifier assigned by the inverter provider (currently Huawei). Used verbatim as
+     * the {@code station_code} tag in InfluxDB: this is the join key between the PostgreSQL plant
+     * row and its time series. It is not a CUPS and not a CAU -- the regulator's code is
+     * {@code regulatory_code}.
+     */
+    @Column(name = "provider_code")
+    private String providerCode;
     @ManyToOne(fetch = FetchType.LAZY)
     private SupplyEntity supply;
     private String address;
@@ -43,12 +50,12 @@ public class PlantEntity {
         this.name = name;
     }
 
-    public String getCode() {
-        return code;
+    public String getProviderCode() {
+        return providerCode;
     }
 
-    public void setCode(String code) {
-        this.code = code;
+    public void setProviderCode(String providerCode) {
+        this.providerCode = providerCode;
     }
 
     public SupplyEntity getSupply() {
@@ -103,12 +110,12 @@ public class PlantEntity {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof PlantEntity that)) return false;
-        return Objects.equals(getId(), that.getId()) && Objects.equals(getName(), that.getName()) && Objects.equals(getCode(), that.getCode());
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getName(), that.getName()) && Objects.equals(getProviderCode(), that.getProviderCode());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getName(), getCode());
+        return Objects.hash(getId(), getName(), getProviderCode());
     }
 
 
@@ -116,7 +123,7 @@ public class PlantEntity {
 
         private UUID id;
         private String name;
-        private String code;
+        private String providerCode;
         private SupplyEntity supply;
         private String address;
         private String description;
@@ -134,8 +141,8 @@ public class PlantEntity {
             return this;
         }
 
-        public Builder withCode(String code) {
-            this.code = code;
+        public Builder withProviderCode(String providerCode) {
+            this.providerCode = providerCode;
             return this;
         }
 
@@ -174,7 +181,7 @@ public class PlantEntity {
 
             plantEntity.setId(id);
             plantEntity.setName(name);
-            plantEntity.setCode(code);
+            plantEntity.setProviderCode(providerCode);
             plantEntity.setSupply(supply);
             plantEntity.setAddress(address);
             plantEntity.setDescription(description);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantEntityMapper.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantEntityMapper.java
@@ -20,7 +20,7 @@ public class PlantEntityMapper extends BaseMapper<PlantEntity, Plant> {
     public Plant map(PlantEntity entity) {
         return new Plant.Builder()
                 .withId(entity.getId())
-                .withCode(entity.getCode())
+                .withProviderCode(entity.getProviderCode())
                 .withAddress(entity.getAddress())
                 .withName(entity.getName())
                 .withSupply(supplyEntityMapper.map(entity.getSupply()))

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantExceptionHandler.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantExceptionHandler.java
@@ -27,11 +27,11 @@ public class PlantExceptionHandler {
     @ExceptionHandler(PlantAlreadyExistsException.class)
     public ResponseEntity<RestError> handleException(PlantAlreadyExistsException e) {
 
-        String plantCode = e.getCode().toString();
+        String plantProviderCode = e.getProviderCode().toString();
 
         String message = messageSource.getMessage(
                 "error.plant.already.exists",
-                Collections.singletonList(plantCode).toArray(),
+                Collections.singletonList(plantProviderCode).toArray(),
                 LocaleContextHolder.getLocale()
         );
         return errorBuilder.build(message, HttpStatus.BAD_REQUEST);
@@ -40,7 +40,7 @@ public class PlantExceptionHandler {
     @ExceptionHandler(PlantNotFoundException.class)
     public ResponseEntity<RestError> handleException(PlantNotFoundException e) {
 
-        String plantIdentifier = e.getId() != null ? e.getId().toString() : e.getCode();
+        String plantIdentifier = e.getId() != null ? e.getId().toString() : e.getProviderCode();
 
         String message = messageSource.getMessage(
                 "error.plant.not.found",

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantRepository.java
@@ -16,9 +16,9 @@ public interface PlantRepository extends JpaRepository<PlantEntity, UUID> {
 
     List<PlantEntity> findAllByInverterProvider(InverterProvider provider);
 
-    int countByCode(String code);
+    int countByProviderCode(String providerCode);
 
-    Optional<PlantEntity> findByCode(String code);
+    Optional<PlantEntity> findByProviderCode(String providerCode);
 
     /**
      * Plants whose supply belongs to any of the given communities. An empty collection yields an empty page.
@@ -26,16 +26,16 @@ public interface PlantRepository extends JpaRepository<PlantEntity, UUID> {
     Page<PlantEntity> findBySupplyCommunityIdIn(Collection<UUID> communityIds, Pageable pageable);
 
     /**
-     * Codes of the plants whose supply belongs to the given community. These codes match the
-     * {@code station_code} tag used in InfluxDB, so they can be used to scope time-series queries.
+     * Provider codes of the plants whose supply belongs to the given community. These codes match
+     * the {@code station_code} tag used in InfluxDB, so they can be used to scope time-series queries.
      */
-    @Query("SELECT p.code FROM plants p WHERE p.supply.community.id = :communityId")
-    List<String> findCodesByCommunityId(@Param("communityId") UUID communityId);
+    @Query("SELECT p.providerCode FROM plants p WHERE p.supply.community.id = :communityId")
+    List<String> findProviderCodesByCommunityId(@Param("communityId") UUID communityId);
 
     /**
      * Supply codes (CUPS) of the plants whose supply belongs to the given community. Unlike
-     * {@link #findCodesByCommunityId(UUID)} (the plant/station code), this returns the CUPS used
-     * as the {@code cups} tag in the Datadis measurements.
+     * {@link #findProviderCodesByCommunityId(UUID)} (the plant/station provider code), this returns
+     * the CUPS used as the {@code cups} tag in the Datadis measurements.
      */
     @Query("SELECT p.supply.code FROM plants p WHERE p.supply.community.id = :communityId")
     List<String> findSupplyCodesByCommunityId(@Param("communityId") UUID communityId);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantResponse.java
@@ -1,5 +1,6 @@
 package org.lucoenergia.conluz.infrastructure.production.plant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.lucoenergia.conluz.domain.production.InverterProvider;
 import org.lucoenergia.conluz.domain.production.plant.Plant;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyResponse;
@@ -10,7 +11,11 @@ import java.util.UUID;
 public class PlantResponse {
 
     private final UUID id;
-    private final String code;
+    @Schema(description = "The plant identifier assigned by the inverter provider (currently Huawei). " +
+            "Used verbatim as the station_code tag in InfluxDB: this is the join key between the " +
+            "PostgreSQL plant row and its time series. It is not a CUPS and not a CAU -- the " +
+            "regulator's code is regulatory_code.")
+    private final String providerCode;
     private final SupplyResponse supply;
     private final String name;
     private final String address;
@@ -21,7 +26,7 @@ public class PlantResponse {
 
     public PlantResponse(Plant plant) {
         this.id = plant.getId();
-        this.code = plant.getCode();
+        this.providerCode = plant.getProviderCode();
         this.supply = new SupplyResponse(plant.getSupply());
         this.name = plant.getName();
         this.address = plant.getAddress();
@@ -35,8 +40,8 @@ public class PlantResponse {
         return id;
     }
 
-    public String getCode() {
-        return code;
+    public String getProviderCode() {
+        return providerCode;
     }
 
     public SupplyResponse getSupply() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreatePlantBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreatePlantBody.java
@@ -11,12 +11,16 @@ import org.lucoenergia.conluz.domain.production.plant.Plant;
 import java.time.LocalDate;
 
 @Schema(requiredProperties = {
-        "code", "name", "address", "totalPower"
+        "providerCode", "name", "address", "totalPower"
 })
 public class CreatePlantBody {
 
+    @Schema(description = "The plant identifier assigned by the inverter provider (currently Huawei). " +
+            "Used verbatim as the station_code tag in InfluxDB: this is the join key between the " +
+            "PostgreSQL plant row and its time series. It is not a CUPS and not a CAU -- the " +
+            "regulator's code is regulatory_code.")
     @NotBlank
-    private String code;
+    private String providerCode;
     @NotBlank
     private String name;
     private String description;
@@ -30,12 +34,12 @@ public class CreatePlantBody {
     @Positive
     private Double totalPower;
 
-    public String getCode() {
-        return code;
+    public String getProviderCode() {
+        return providerCode;
     }
 
-    public void setCode(String code) {
-        this.code = code;
+    public void setProviderCode(String providerCode) {
+        this.providerCode = providerCode;
     }
 
     public String getName() {
@@ -96,7 +100,7 @@ public class CreatePlantBody {
 
     public Plant mapToPlant() {
         Plant.Builder builder = new Plant.Builder();
-        builder.withCode(code)
+        builder.withProviderCode(providerCode)
                 .withAddress(address)
                 .withName(name)
                 .withDescription(description)

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreatePlantRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreatePlantRepositoryDatabase.java
@@ -5,7 +5,7 @@ import org.lucoenergia.conluz.domain.production.plant.Plant;
 import org.lucoenergia.conluz.domain.production.plant.PlantAlreadyExistsException;
 import org.lucoenergia.conluz.domain.production.plant.PlantCannotBeCreatedException;
 import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
-import org.lucoenergia.conluz.domain.shared.PlantCode;
+import org.lucoenergia.conluz.domain.shared.PlantProviderCode;
 import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMapper;
@@ -42,14 +42,14 @@ public class CreatePlantRepositoryDatabase implements CreatePlantRepository {
         if (result.isEmpty()) {
             throw new SupplyNotFoundException(id);
         }
-        if (plantRepository.countByCode(plant.getCode()) > 0) {
-            throw new PlantAlreadyExistsException(PlantCode.of(plant.getCode()));
+        if (plantRepository.countByProviderCode(plant.getProviderCode()) > 0) {
+            throw new PlantAlreadyExistsException(PlantProviderCode.of(plant.getProviderCode()));
         }
 
         SupplyEntity supplyEntity = result.get();
         PlantEntity plantEntity = new PlantEntity.Builder()
                 .withId(UUID.randomUUID())
-                .withCode(plant.getCode())
+                .withProviderCode(plant.getProviderCode())
                 .withName(plant.getName())
                 .withAddress(plant.getAddress())
                 .withDescription(plant.getDescription())
@@ -62,7 +62,7 @@ public class CreatePlantRepositoryDatabase implements CreatePlantRepository {
 
         supplyRepository.save(supplyEntity);
 
-        Optional<PlantEntity> newPlantEntity = plantRepository.findByCode(plant.getCode());
+        Optional<PlantEntity> newPlantEntity = plantRepository.findByProviderCode(plant.getProviderCode());
         if (newPlantEntity.isEmpty()) {
             throw new PlantCannotBeCreatedException();
         }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantRepositoryDatabase.java
@@ -58,8 +58,8 @@ public class GetPlantRepositoryDatabase implements GetPlantRepository {
     }
 
     @Override
-    public List<String> findPlantCodesByCommunity(UUID communityId) {
-        return plantRepository.findCodesByCommunityId(communityId);
+    public List<String> findPlantProviderCodesByCommunity(UUID communityId) {
+        return plantRepository.findProviderCodesByCommunityId(communityId);
     }
 
     @Override

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantServiceImpl.java
@@ -40,9 +40,9 @@ public class GetPlantServiceImpl implements GetPlantService {
     }
 
     private void applyDefaultSort(PagedRequest pagedRequest) {
-        // If no sorting is provided, sort by code ascending by default
+        // If no sorting is provided, sort by provider code ascending by default
         if (!pagedRequest.isSorted()) {
-            final Order defaultOrder = new Order(Direction.ASC, "code");
+            final Order defaultOrder = new Order(Direction.ASC, "providerCode");
             pagedRequest.addOrder(defaultOrder);
         }
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantBody.java
@@ -10,12 +10,16 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 @Schema(requiredProperties = {
-        "code", "name", "address", "totalPower", "personalId", "inverterProvider"
+        "providerCode", "name", "address", "totalPower", "personalId", "inverterProvider"
 })
 public class UpdatePlantBody {
 
+    @Schema(description = "The plant identifier assigned by the inverter provider (currently Huawei). " +
+            "Used verbatim as the station_code tag in InfluxDB: this is the join key between the " +
+            "PostgreSQL plant row and its time series. It is not a CUPS and not a CAU -- the " +
+            "regulator's code is regulatory_code.")
     @NotBlank
-    private String code;
+    private String providerCode;
     @NotBlank
     private String name;
     private String description;
@@ -29,12 +33,12 @@ public class UpdatePlantBody {
     @Positive
     private Double totalPower;
 
-    public String getCode() {
-        return code;
+    public String getProviderCode() {
+        return providerCode;
     }
 
-    public void setCode(String code) {
-        this.code = code;
+    public void setProviderCode(String providerCode) {
+        this.providerCode = providerCode;
     }
 
     public String getName() {
@@ -96,7 +100,7 @@ public class UpdatePlantBody {
     public Plant toPlant(UUID uuid) {
         Plant.Builder builder = new Plant.Builder();
         builder.withId(uuid)
-                .withCode(code)
+                .withProviderCode(providerCode)
                 .withName(name)
                 .withDescription(description)
                 .withInverterProvider(inverterProvider)

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantRepositoryDatabase.java
@@ -40,7 +40,7 @@ public class UpdatePlantRepositoryDatabase implements UpdatePlantRepository {
             throw new PlantNotFoundException(PlantId.of(plantId));
         }
         PlantEntity currentPlant = result.get();
-        currentPlant.setCode(plant.getCode());
+        currentPlant.setProviderCode(plant.getProviderCode());
         currentPlant.setName(plant.getName());
         currentPlant.setDescription(plant.getDescription());
         currentPlant.setAddress(plant.getAddress());

--- a/src/main/resources/db/liquibase/changelogs/rename_plants_code_to_provider_code.xml
+++ b/src/main/resources/db/liquibase/changelogs/rename_plants_code_to_provider_code.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <changeSet author="Víctor Cañizares" id="rename_plants_code_to_provider_code">
+        <renameColumn tableName="plants"
+                      oldColumnName="code"
+                      newColumnName="provider_code"
+                      columnDataType="text"
+                      remarks="The plant identifier assigned by the inverter provider (currently Huawei). Used verbatim as the station_code tag in InfluxDB: this is the join key between the PostgreSQL plant row and its time series. It is not a CUPS and not a CAU -- the regulator's code is regulatory_code."/>
+        <rollback>
+            <renameColumn tableName="plants"
+                          oldColumnName="provider_code"
+                          newColumnName="code"
+                          columnDataType="text"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/db.changelog-main.xml
+++ b/src/main/resources/db/liquibase/db.changelog-main.xml
@@ -41,4 +41,5 @@ http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
     <include file="changelogs/drop_role_from_users.xml" relativeToChangelogFile="true" />
     <include file="changelogs/drop_supplies_datadis_table.xml" relativeToChangelogFile="true" />
     <include file="changelogs/backfill_platform_admins.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/rename_plants_code_to_provider_code.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/test/java/org/lucoenergia/conluz/domain/production/plant/PlantMother.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/production/plant/PlantMother.java
@@ -19,7 +19,7 @@ public class PlantMother {
     public static Plant.Builder random(Supply supply) {
         return new Plant.Builder()
                 .withId(UUID.randomUUID())
-                .withCode(RandomStringUtils.random(20, true, true))
+                .withProviderCode(RandomStringUtils.random(20, true, true))
                 .withName(RandomStringUtils.random(10, true, false))
                 .withDescription(RandomStringUtils.random(30, true, false))
                 .withTotalPower(new Random().nextDouble())
@@ -33,7 +33,7 @@ public class PlantMother {
     public static PlantEntity.Builder randomPlantEntity() {
         return new PlantEntity.Builder()
                 .withId(UUID.randomUUID())
-                .withCode(RandomStringUtils.random(20, true, true))
+                .withProviderCode(RandomStringUtils.random(20, true, true))
                 .withName(RandomStringUtils.random(10, true, false))
                 .withDescription(RandomStringUtils.random(30, true, false))
                 .withTotalPower(new Random().nextDouble())

--- a/src/test/java/org/lucoenergia/conluz/domain/production/plant/get/GetPlantServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/production/plant/get/GetPlantServiceTest.java
@@ -109,7 +109,7 @@ class GetPlantServiceTest {
     }
 
     @Test
-    void findAllByCommunitiesAppliesDefaultSortByCodeWhenRequestIsUnsorted() {
+    void findAllByCommunitiesAppliesDefaultSortByProviderCodeWhenRequestIsUnsorted() {
         // arrange
         PagedRequest pagedRequest = PagedRequest.of(0, 10);
         when(repository.findAll(any())).thenReturn(new PagedResult<>(Collections.emptyList(), 0, 0L, 0, 0));
@@ -122,7 +122,7 @@ class GetPlantServiceTest {
         verify(repository).findAll(captor.capture());
         List<Order> orders = captor.getValue().getOrders();
         assertEquals(1, orders.size());
-        assertEquals("code", orders.get(0).getProperty());
+        assertEquals("providerCode", orders.get(0).getProperty());
         assertEquals(Direction.ASC, orders.get(0).getDirection());
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyDailyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyDailyProductionControllerTest.java
@@ -56,7 +56,7 @@ class GetSupplyDailyProductionControllerTest extends BaseControllerTest {
         User plantOwner = createUserRepository.create(UserMother.randomUser());
         Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
         createPlantRepository.create(
-                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                PlantMother.random(plantSupply).withProviderCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
                 SupplyId.of(plantSupply.getId()));
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyHourlyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyHourlyProductionControllerTest.java
@@ -56,7 +56,7 @@ class GetSupplyHourlyProductionControllerTest extends BaseControllerTest {
         User plantOwner = createUserRepository.create(UserMother.randomUser());
         Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
         createPlantRepository.create(
-                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                PlantMother.random(plantSupply).withProviderCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
                 SupplyId.of(plantSupply.getId()));
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyMonthlyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyMonthlyProductionControllerTest.java
@@ -56,7 +56,7 @@ class GetSupplyMonthlyProductionControllerTest extends BaseControllerTest {
         User plantOwner = createUserRepository.create(UserMother.randomUser());
         Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
         createPlantRepository.create(
-                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                PlantMother.random(plantSupply).withProviderCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
                 SupplyId.of(plantSupply.getId()));
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHourlyProductionControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHourlyProductionControllerTest.java
@@ -51,7 +51,7 @@ class GetHourlyProductionControllerTest extends BaseControllerTest {
         User plantOwner = createUserRepository.create(UserMother.randomUser());
         Supply plantSupply = createSupplyRepository.create(SupplyMother.random().build(), UserId.of(plantOwner.getId()));
         createPlantRepository.create(
-                PlantMother.random(plantSupply).withCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
+                PlantMother.random(plantSupply).withProviderCode(EnergyProductionInfluxLoader.STATION_CODE).build(),
                 SupplyId.of(plantSupply.getId()));
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiHourlyProductionRepositoryRestIntegrationTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiHourlyProductionRepositoryRestIntegrationTest.java
@@ -31,7 +31,7 @@ class GetHuaweiHourlyProductionRepositoryRestIntegrationTest extends BaseIntegra
     void getHourlyProduction_shouldReturnProductionByDateIntervalWhenStationCodesIsNotEmpty() {
         // Given
         String stationCode = "code";
-        List<Plant> stationCodes = List.of(new Plant.Builder().withCode(stationCode).build());
+        List<Plant> stationCodes = List.of(new Plant.Builder().withProviderCode(stationCode).build());
 
         String username = "username";
         String password = "password";

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiHourlyProductionRepositoryRestTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiHourlyProductionRepositoryRestTest.java
@@ -42,8 +42,8 @@ class GetHuaweiHourlyProductionRepositoryRestTest {
     private GetHuaweiHourlyProductionRepositoryRest repositoryRest;
 
     private static final List<Plant> STATION_CODES = Arrays.asList(
-            new Plant.Builder().withCode("BA4372D08E014822AB065017416F254C").build(),
-            new Plant.Builder().withCode("5D02E8B40AD342159AC8D8A2BCD4FAB5").build()
+            new Plant.Builder().withProviderCode("BA4372D08E014822AB065017416F254C").build(),
+            new Plant.Builder().withProviderCode("5D02E8B40AD342159AC8D8A2BCD4FAB5").build()
     );
 
     private static final String RESPONSE_BODY_ACCESS_FREQUENCY_IS_TOO_HIGH = """

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiRealTimeProductionRepositoryRestIntegrationTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiRealTimeProductionRepositoryRestIntegrationTest.java
@@ -30,7 +30,7 @@ class GetHuaweiRealTimeProductionRepositoryRestIntegrationTest extends BaseInteg
     void getRealTimeProduction_shouldReturnProductionWhenStationCodesIsNotEmpty() {
         // Given
         String stationCode = "code";
-        List<Plant> stationCodes = List.of(new Plant.Builder().withCode(stationCode).build());
+        List<Plant> stationCodes = List.of(new Plant.Builder().withProviderCode(stationCode).build());
 
         String username = "username";
         String password = "password";

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiRealTimeProductionRepositoryRestTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetHuaweiRealTimeProductionRepositoryRestTest.java
@@ -64,8 +64,8 @@ class GetHuaweiRealTimeProductionRepositoryRestTest {
     void getRealTimeProduction_shouldReturnProductionWhenStationCodesIsNotEmpty() throws IOException {
         // Given
         List<Plant> stationCodes = Arrays.asList(
-                new Plant.Builder().withCode("BA4372D08E014822AB065017416F254C").build(),
-                new Plant.Builder().withCode("5D02E8B40AD342159AC8D8A2BCD4FAB5").build()
+                new Plant.Builder().withProviderCode("BA4372D08E014822AB065017416F254C").build(),
+                new Plant.Builder().withProviderCode("5D02E8B40AD342159AC8D8A2BCD4FAB5").build()
         );
 
         String responseBodyString = """

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImplIntegrationTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceImplIntegrationTest.java
@@ -79,7 +79,7 @@ class GetProductionServiceImplIntegrationTest extends BaseIntegrationTest {
                 SupplyMother.random().withPartitionCoefficient(1.0f).build(),
                 UserId.of(user.getId()), community.getId());
         createPlantRepository.create(
-                PlantMother.random(supply).withCode(stationCode).build(), SupplyId.of(supply.getId()));
+                PlantMother.random(supply).withProviderCode(stationCode).build(), SupplyId.of(supply.getId()));
         return supply;
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/get/GetProductionServiceTest.java
@@ -58,7 +58,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 10d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate, 0.4f, stationCodes))
                 .thenReturn(expected);
 
@@ -106,7 +106,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 5d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate, 0.25f, stationCodes))
                 .thenReturn(expected);
 
@@ -154,7 +154,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 100d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate, 0.75f, stationCodes))
                 .thenReturn(expected);
 
@@ -198,7 +198,7 @@ class GetProductionServiceTest {
         List<String> stationCodes = List.of("PLANT001", "PLANT002");
         InstantProduction expected = new InstantProduction(42d);
 
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getInstantProduction(stationCodes)).thenReturn(expected);
 
         InstantProduction result = service.getInstantProductionByCommunity(communityId);
@@ -218,7 +218,7 @@ class GetProductionServiceTest {
         List<String> stationCodes = List.of("PLANT001");
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getInstantProduction(stationCodes)).thenReturn(new InstantProduction(80d));
 
         InstantProduction result = service.getInstantProductionByCommunityAndSupply(communityId, supplyId);
@@ -260,7 +260,7 @@ class GetProductionServiceTest {
         List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 10d));
 
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate, 1f, stationCodes))
                 .thenReturn(expected);
 
@@ -282,7 +282,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 3d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getHourlyProductionByRangeOfDates(startDate, endDate, 0.3f, stationCodes))
                 .thenReturn(expected);
 
@@ -299,7 +299,7 @@ class GetProductionServiceTest {
         List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 11d));
 
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate, 1f, stationCodes))
                 .thenReturn(expected);
 
@@ -321,7 +321,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 6d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getDailyProductionByRangeOfDates(startDate, endDate, 0.6f, stationCodes))
                 .thenReturn(expected);
 
@@ -338,7 +338,7 @@ class GetProductionServiceTest {
         List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 12d));
 
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate, 1f, stationCodes))
                 .thenReturn(expected);
 
@@ -360,7 +360,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 2d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getMonthlyProductionByRangeOfDates(startDate, endDate, 0.2f, stationCodes))
                 .thenReturn(expected);
 
@@ -377,7 +377,7 @@ class GetProductionServiceTest {
         List<String> stationCodes = List.of("PLANT001");
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 13d));
 
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getYearlyProductionByRangeOfDates(startDate, endDate, 1f, stationCodes))
                 .thenReturn(expected);
 
@@ -399,7 +399,7 @@ class GetProductionServiceTest {
         List<ProductionByTime> expected = List.of(new ProductionByTime(startDate, 9d));
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.of(supply));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(stationCodes);
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(stationCodes);
         when(getProductionRepository.getYearlyProductionByRangeOfDates(startDate, endDate, 0.9f, stationCodes))
                 .thenReturn(expected);
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationRepositoryInfluxTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationRepositoryInfluxTest.java
@@ -52,7 +52,7 @@ class HuaweiProductionMonthlyAggregationRepositoryInfluxTest extends BaseIntegra
 
     @BeforeEach
     void setUp() {
-        plant = PlantMother.random().withCode(STATION_CODE).build();
+        plant = PlantMother.random().withProviderCode(STATION_CODE).build();
         loadHourlyDataForApril2023();
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionMonthlyAggregationServiceTest.java
@@ -122,10 +122,10 @@ class HuaweiProductionMonthlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant1 = PlantMother.random().build();
         Plant plant2 = PlantMother.random().build();
-        when(getPlantRepository.findPlantCodesByCommunity(communityId))
-                .thenReturn(List.of(plant1.getCode(), plant2.getCode()));
-        when(getEnergyStationRepository.findByCode(plant1.getCode())).thenReturn(Optional.of(plant1));
-        when(getEnergyStationRepository.findByCode(plant2.getCode())).thenReturn(Optional.of(plant2));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId))
+                .thenReturn(List.of(plant1.getProviderCode(), plant2.getProviderCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant1.getProviderCode())).thenReturn(Optional.of(plant1));
+        when(getEnergyStationRepository.findByProviderCode(plant2.getProviderCode())).thenReturn(Optional.of(plant2));
 
         service.aggregateMonthlyProductions(communityId, 2024);
 
@@ -141,10 +141,10 @@ class HuaweiProductionMonthlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant1 = PlantMother.random().build();
         Plant plant2 = PlantMother.random().build();
-        when(getPlantRepository.findPlantCodesByCommunity(communityId))
-                .thenReturn(List.of(plant1.getCode(), plant2.getCode()));
-        when(getEnergyStationRepository.findByCode(plant1.getCode())).thenReturn(Optional.of(plant1));
-        when(getEnergyStationRepository.findByCode(plant2.getCode())).thenReturn(Optional.of(plant2));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId))
+                .thenReturn(List.of(plant1.getProviderCode(), plant2.getProviderCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant1.getProviderCode())).thenReturn(Optional.of(plant1));
+        when(getEnergyStationRepository.findByProviderCode(plant2.getProviderCode())).thenReturn(Optional.of(plant2));
 
         service.aggregateMonthlyProductions(communityId, Month.JULY, 2024);
 
@@ -158,10 +158,10 @@ class HuaweiProductionMonthlyAggregationServiceTest {
     void testAggregateMonthlyForSpecificPlant() {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(List.of(plant.getCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(List.of(plant.getProviderCode()));
 
-        service.aggregateMonthlyProductions(communityId, plant.getCode(), Month.AUGUST, 2024);
+        service.aggregateMonthlyProductions(communityId, plant.getProviderCode(), Month.AUGUST, 2024);
 
         verify(aggregationRepository, times(1))
                 .aggregateMonthlyProduction(eq(plant), eq(Month.AUGUST), eq(2024));
@@ -170,11 +170,11 @@ class HuaweiProductionMonthlyAggregationServiceTest {
     @Test
     void testAggregateMonthlyForSpecificPlant_whenPlantNotFound_thenThrows() {
         UUID communityId = UUID.randomUUID();
-        String plantCode = "UNKNOWN";
-        when(getEnergyStationRepository.findByCode(plantCode)).thenReturn(Optional.empty());
+        String plantProviderCode = "UNKNOWN";
+        when(getEnergyStationRepository.findByProviderCode(plantProviderCode)).thenReturn(Optional.empty());
 
         assertThrows(PlantNotFoundException.class,
-                () -> service.aggregateMonthlyProductions(communityId, plantCode, Month.AUGUST, 2024));
+                () -> service.aggregateMonthlyProductions(communityId, plantProviderCode, Month.AUGUST, 2024));
 
         verify(aggregationRepository, never())
                 .aggregateMonthlyProduction(any(Plant.class), any(Month.class), anyInt());
@@ -184,11 +184,11 @@ class HuaweiProductionMonthlyAggregationServiceTest {
     void testAggregateMonthlyForSpecificPlant_whenPlantNotInCommunity_thenThrows() {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(Collections.emptyList());
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(Collections.emptyList());
 
         assertThrows(PlantNotFoundException.class,
-                () -> service.aggregateMonthlyProductions(communityId, plant.getCode(), Month.AUGUST, 2024));
+                () -> service.aggregateMonthlyProductions(communityId, plant.getProviderCode(), Month.AUGUST, 2024));
 
         verify(aggregationRepository, never())
                 .aggregateMonthlyProduction(any(Plant.class), any(Month.class), anyInt());
@@ -213,8 +213,8 @@ class HuaweiProductionMonthlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
         when(getHuaweiConfigRepository.getEnabledHuaweiConfigs()).thenReturn(List.of(configForPlant(UUID.randomUUID())));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(List.of(plant.getCode()));
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(List.of(plant.getProviderCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
 
         service.syncMonthlyProductions(communityId, null, null, 2024);
 
@@ -226,10 +226,10 @@ class HuaweiProductionMonthlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
         when(getHuaweiConfigRepository.getEnabledHuaweiConfigs()).thenReturn(List.of(configForPlant(UUID.randomUUID())));
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(List.of(plant.getCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(List.of(plant.getProviderCode()));
 
-        service.syncMonthlyProductions(communityId, plant.getCode(), 6, 2024);
+        service.syncMonthlyProductions(communityId, plant.getProviderCode(), 6, 2024);
 
         verify(aggregationRepository, times(1)).aggregateMonthlyProduction(eq(plant), eq(Month.JUNE), eq(2024));
     }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationRepositoryInfluxTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationRepositoryInfluxTest.java
@@ -51,7 +51,7 @@ class HuaweiProductionYearlyAggregationRepositoryInfluxTest extends BaseIntegrat
 
     @BeforeEach
     void setUp() {
-        plant = PlantMother.random().withCode(STATION_CODE).build();
+        plant = PlantMother.random().withProviderCode(STATION_CODE).build();
         clearMonthlyMeasurementForStation();
         loadMonthlyDataFor2023();
     }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/huawei/aggregate/HuaweiProductionYearlyAggregationServiceTest.java
@@ -118,10 +118,10 @@ class HuaweiProductionYearlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant1 = PlantMother.random().build();
         Plant plant2 = PlantMother.random().build();
-        when(getPlantRepository.findPlantCodesByCommunity(communityId))
-                .thenReturn(List.of(plant1.getCode(), plant2.getCode()));
-        when(getEnergyStationRepository.findByCode(plant1.getCode())).thenReturn(Optional.of(plant1));
-        when(getEnergyStationRepository.findByCode(plant2.getCode())).thenReturn(Optional.of(plant2));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId))
+                .thenReturn(List.of(plant1.getProviderCode(), plant2.getProviderCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant1.getProviderCode())).thenReturn(Optional.of(plant1));
+        when(getEnergyStationRepository.findByProviderCode(plant2.getProviderCode())).thenReturn(Optional.of(plant2));
 
         service.aggregateYearlyProductions(communityId, 2024);
 
@@ -133,10 +133,10 @@ class HuaweiProductionYearlyAggregationServiceTest {
     void testAggregateYearlyForSpecificPlant() {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(List.of(plant.getCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(List.of(plant.getProviderCode()));
 
-        service.aggregateYearlyProductions(communityId, plant.getCode(), 2024);
+        service.aggregateYearlyProductions(communityId, plant.getProviderCode(), 2024);
 
         verify(aggregationRepository, times(1)).aggregateYearlyProduction(eq(plant), eq(2024));
     }
@@ -144,11 +144,11 @@ class HuaweiProductionYearlyAggregationServiceTest {
     @Test
     void testAggregateYearlyForSpecificPlant_whenPlantNotFound_thenThrows() {
         UUID communityId = UUID.randomUUID();
-        String plantCode = "UNKNOWN";
-        when(getEnergyStationRepository.findByCode(plantCode)).thenReturn(Optional.empty());
+        String plantProviderCode = "UNKNOWN";
+        when(getEnergyStationRepository.findByProviderCode(plantProviderCode)).thenReturn(Optional.empty());
 
         assertThrows(PlantNotFoundException.class,
-                () -> service.aggregateYearlyProductions(communityId, plantCode, 2024));
+                () -> service.aggregateYearlyProductions(communityId, plantProviderCode, 2024));
 
         verify(aggregationRepository, never()).aggregateYearlyProduction(any(Plant.class), anyInt());
     }
@@ -157,11 +157,11 @@ class HuaweiProductionYearlyAggregationServiceTest {
     void testAggregateYearlyForSpecificPlant_whenPlantNotInCommunity_thenThrows() {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(Collections.emptyList());
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(Collections.emptyList());
 
         assertThrows(PlantNotFoundException.class,
-                () -> service.aggregateYearlyProductions(communityId, plant.getCode(), 2024));
+                () -> service.aggregateYearlyProductions(communityId, plant.getProviderCode(), 2024));
 
         verify(aggregationRepository, never()).aggregateYearlyProduction(any(Plant.class), anyInt());
     }
@@ -185,8 +185,8 @@ class HuaweiProductionYearlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
         when(getHuaweiConfigRepository.getEnabledHuaweiConfigs()).thenReturn(List.of(configForPlant(UUID.randomUUID())));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(List.of(plant.getCode()));
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(List.of(plant.getProviderCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
 
         service.syncYearlyProductions(communityId, null, 2024);
 
@@ -198,10 +198,10 @@ class HuaweiProductionYearlyAggregationServiceTest {
         UUID communityId = UUID.randomUUID();
         Plant plant = PlantMother.random().build();
         when(getHuaweiConfigRepository.getEnabledHuaweiConfigs()).thenReturn(List.of(configForPlant(UUID.randomUUID())));
-        when(getEnergyStationRepository.findByCode(plant.getCode())).thenReturn(Optional.of(plant));
-        when(getPlantRepository.findPlantCodesByCommunity(communityId)).thenReturn(List.of(plant.getCode()));
+        when(getEnergyStationRepository.findByProviderCode(plant.getProviderCode())).thenReturn(Optional.of(plant));
+        when(getPlantRepository.findPlantProviderCodesByCommunity(communityId)).thenReturn(List.of(plant.getProviderCode()));
 
-        service.syncYearlyProductions(communityId, plant.getCode(), 2024);
+        service.syncYearlyProductions(communityId, plant.getProviderCode(), 2024);
 
         verify(aggregationRepository, times(1)).aggregateYearlyProduction(eq(plant), eq(2024));
     }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreatePlantControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreatePlantControllerTest.java
@@ -65,7 +65,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
 
         String body = String.format("""
                         {
-                          "code": "%s",
+                          "providerCode": "%s",
                           "name": "Plant one",
                           "supplyCode": "%s",
                           "address": "Fake Street 123",
@@ -83,7 +83,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNotEmpty())
-                .andExpect(jsonPath("$.code").value(plantCode))
+                .andExpect(jsonPath("$.providerCode").value(plantCode))
                 .andExpect(jsonPath("$.address").value("Fake Street 123"))
                 .andExpect(jsonPath("$.name").value("Plant one"))
                 .andExpect(jsonPath("$.description").value("Plant number one"))
@@ -92,7 +92,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.inverterProvider").value("HUAWEI"))
                 .andExpect(jsonPath("$.supply.code").value(supply.getCode()));
 
-        Assertions.assertEquals(1, plantRepository.countByCode(plantCode));
+        Assertions.assertEquals(1, plantRepository.countByProviderCode(plantCode));
     }
 
     @Test
@@ -115,7 +115,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
 
         String body = String.format("""
                         {
-                          "code": "%s",
+                          "providerCode": "%s",
                           "name": "Plant one",
                           "supplyCode": "%s",
                           "address": "Fake Street 123",
@@ -131,7 +131,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNotEmpty())
-                .andExpect(jsonPath("$.code").value(plantCode))
+                .andExpect(jsonPath("$.providerCode").value(plantCode))
                 .andExpect(jsonPath("$.address").value("Fake Street 123"))
                 .andExpect(jsonPath("$.name").value("Plant one"))
                 .andExpect(jsonPath("$.description").isEmpty())
@@ -140,7 +140,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.inverterProvider").value("HUAWEI"))
                 .andExpect(jsonPath("$.supply.code").value(supply.getCode()));
 
-        Assertions.assertEquals(1, plantRepository.countByCode(plantCode));
+        Assertions.assertEquals(1, plantRepository.countByProviderCode(plantCode));
     }
 
     @ParameterizedTest
@@ -173,7 +173,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                                 {
-                                  "code": "TS-65987",
+                                  "providerCode": "TS-65987",
                                   "personalId": "12345678Z",
                                   "address": "Fake Street 123",
                                   "totalPower": "60.00",
@@ -182,7 +182,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                                 {
-                                  "code": "TS-65987",
+                                  "providerCode": "TS-65987",
                                   "name": "Plant one",
                                   "address": "Fake Street 123",
                                   "totalPower": "60.00",
@@ -191,7 +191,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                                 {
-                                  "code": "TS-65987",
+                                  "providerCode": "TS-65987",
                                   "name": "Plant one",
                                   "personalId": "12345678Z",
                                   "totalPower": "60.00",
@@ -200,7 +200,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                                 {
-                                  "code": "TS-65987",
+                                  "providerCode": "TS-65987",
                                   "name": "Plant one",
                                   "personalId": "12345678Z",
                                   "address": "Fake Street 123",
@@ -209,7 +209,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                                 {
-                                  "code": "TS-65987",
+                                  "providerCode": "TS-65987",
                                   "name": "Plant one",
                                   "personalId": "12345678Z",
                                   "address": "Fake Street 123",
@@ -239,7 +239,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
     static List<String> getBodyWithInvalidFormatValues() {
         return List.of("""
                             {
-                              "code": "TS-1234124",
+                              "providerCode": "TS-1234124",
                               "name": "Plant one",
                               "personalId": "12345678Z",
                               "address": "Fake Street 123",
@@ -249,7 +249,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                             {
-                              "code": "TS-1234124",
+                              "providerCode": "TS-1234124",
                               "name": "Plant one",
                               "personalId": "12345678Z",
                               "address": "Fake Street 123",
@@ -259,7 +259,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                             {
-                              "code": "TS-1234124",
+                              "providerCode": "TS-1234124",
                               "name": "Plant one",
                               "personalId": "12345678Z",
                               "address": "Fake Street 123",
@@ -286,7 +286,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
         String plantCode = "PS-456798";
 
         plantRepository.save(new PlantEntity.Builder()
-                .withCode(plantCode)
+                .withProviderCode(plantCode)
                 .withTotalPower(23D)
                 .withAddress("Fake Street 123")
                 .withInverterProvider(InverterProvider.HUAWEI)
@@ -297,7 +297,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
 
         String body = String.format("""
                         {
-                          "code": "%s",
+                          "providerCode": "%s",
                           "name": "Plant one",
                           "supplyCode": "%s",
                           "address": "Fake Street 123",
@@ -357,7 +357,7 @@ class CreatePlantControllerTest extends BaseControllerTest {
 
         String body = String.format("""
                         {
-                          "code": "%s",
+                          "providerCode": "%s",
                           "name": "Plant one",
                           "supplyCode": "%s",
                           "address": "Fake Street 123",

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeletePlantControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeletePlantControllerTest.java
@@ -56,11 +56,11 @@ class DeletePlantControllerTest extends BaseControllerTest {
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
         // Create three supplies
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
-        Plant plantTwo = PlantMother.random(supplyOne).withCode("TS-123456").build();
+        Plant plantTwo = PlantMother.random(supplyOne).withProviderCode("TS-123456").build();
         plantTwo = createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
-        Plant plantThree = PlantMother.random(supplyTwo).withCode("TS-789456").build();
+        Plant plantThree = PlantMother.random(supplyTwo).withProviderCode("TS-789456").build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
 
         // Login as an admin of the plant's community

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetAllPlantsControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetAllPlantsControllerTest.java
@@ -53,11 +53,11 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
         // Create three supplies
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
-        Plant plantTwo = PlantMother.random(supplyOne).withCode("TS-123456").build();
+        Plant plantTwo = PlantMother.random(supplyOne).withProviderCode("TS-123456").build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
-        Plant plantThree = PlantMother.random(supplyTwo).withCode("TS-789456").build();
+        Plant plantThree = PlantMother.random(supplyTwo).withProviderCode("TS-789456").build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
 
         String authHeader = loginAsCommunityMember(DEFAULT_COMMUNITY_ID);
@@ -73,7 +73,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.items.size()").value(3))
 
                 .andExpect(jsonPath("$.items[0].id").isNotEmpty())
-                .andExpect(jsonPath("$.items[0].code").value(plantTwo.getCode()))
+                .andExpect(jsonPath("$.items[0].providerCode").value(plantTwo.getProviderCode()))
                 .andExpect(jsonPath("$.items[0].name").value(plantTwo.getName()))
                 .andExpect(jsonPath("$.items[0].address").value(plantTwo.getAddress()))
                 .andExpect(jsonPath("$.items[0].description").value(plantTwo.getDescription()))
@@ -83,7 +83,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.items[0].supply.code").value(plantTwo.getSupply().getCode()))
 
                 .andExpect(jsonPath("$.items[1].id").isNotEmpty())
-                .andExpect(jsonPath("$.items[1].code").value(plantOne.getCode()))
+                .andExpect(jsonPath("$.items[1].providerCode").value(plantOne.getProviderCode()))
                 .andExpect(jsonPath("$.items[1].name").value(plantOne.getName()))
                 .andExpect(jsonPath("$.items[1].address").value(plantOne.getAddress()))
                 .andExpect(jsonPath("$.items[1].description").value(plantOne.getDescription()))
@@ -93,7 +93,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.items[1].supply.code").value(plantOne.getSupply().getCode()))
 
                 .andExpect(jsonPath("$.items[2].id").isNotEmpty())
-                .andExpect(jsonPath("$.items[2].code").value(plantThree.getCode()))
+                .andExpect(jsonPath("$.items[2].providerCode").value(plantThree.getProviderCode()))
                 .andExpect(jsonPath("$.items[2].name").value(plantThree.getName()))
                 .andExpect(jsonPath("$.items[2].address").value(plantThree.getAddress()))
                 .andExpect(jsonPath("$.items[2].description").value(plantThree.getDescription()))
@@ -131,11 +131,11 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         Supply supplyTwo = SupplyMother.random().build();
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
-        Plant plantTwo = PlantMother.random(supplyOne).withCode("TS-123456").build();
+        Plant plantTwo = PlantMother.random(supplyOne).withProviderCode("TS-123456").build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
-        Plant plantThree = PlantMother.random(supplyTwo).withCode("TS-789456").build();
+        Plant plantThree = PlantMother.random(supplyTwo).withProviderCode("TS-789456").build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
 
         String authHeader = loginAsCommunityMember(DEFAULT_COMMUNITY_ID);
@@ -151,7 +151,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.totalPages").value("3"))
                 .andExpect(jsonPath("$.number").value("1"))
                 .andExpect(jsonPath("$.items.size()").value(1))
-                .andExpect(jsonPath("$.items[0].code").value(plantOne.getCode()));
+                .andExpect(jsonPath("$.items[0].providerCode").value(plantOne.getProviderCode()));
     }
 
     @Test
@@ -162,7 +162,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         Supply supplyOne = SupplyMother.random().build();
         supplyOne = createSupplyRepository.create(supplyOne, UserId.of(userOne.getId()));
 
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
 
         String authHeader = loginAsCommunityMember(DEFAULT_COMMUNITY_ID);
@@ -177,7 +177,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.totalPages").value("1"))
                 .andExpect(jsonPath("$.number").value("0"))
                 .andExpect(jsonPath("$.items.size()").value(1))
-                .andExpect(jsonPath("$.items[0].code").value(plantOne.getCode()));
+                .andExpect(jsonPath("$.items[0].providerCode").value(plantOne.getProviderCode()));
     }
 
     @Test
@@ -208,11 +208,11 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         Supply supplyTwo = SupplyMother.random().build();
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
-        Plant plantTwo = PlantMother.random(supplyOne).withCode("TS-123456").build();
+        Plant plantTwo = PlantMother.random(supplyOne).withProviderCode("TS-123456").build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
-        Plant plantThree = PlantMother.random(supplyTwo).withCode("TS-789456").build();
+        Plant plantThree = PlantMother.random(supplyTwo).withProviderCode("TS-789456").build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
 
         String authHeader = loginAsCommunityMember(DEFAULT_COMMUNITY_ID);
@@ -240,11 +240,11 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         Supply supplyTwo = SupplyMother.random().build();
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
-        Plant plantTwo = PlantMother.random(supplyOne).withCode("TS-123456").build();
+        Plant plantTwo = PlantMother.random(supplyOne).withProviderCode("TS-123456").build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
-        Plant plantThree = PlantMother.random(supplyTwo).withCode("TS-789456").build();
+        Plant plantThree = PlantMother.random(supplyTwo).withProviderCode("TS-789456").build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
 
         String authHeader = loginAsCommunityMember(DEFAULT_COMMUNITY_ID);
@@ -273,17 +273,17 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
         Plant plantOne = PlantMother.random(supplyOne)
-                .withCode("TS-456789")
+                .withProviderCode("TS-456789")
                 .withName("Plant One")
                 .build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
         Plant plantTwo = PlantMother.random(supplyOne)
-                .withCode("TS-123456")
+                .withProviderCode("TS-123456")
                 .withName("Plant Two")
                 .build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
         Plant plantThree = PlantMother.random(supplyTwo)
-                .withCode("TS-789456")
+                .withProviderCode("TS-789456")
                 .withName("Plant Three")
                 .build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
@@ -300,9 +300,9 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.totalPages").value("1"))
                 .andExpect(jsonPath("$.number").value("0"))
                 .andExpect(jsonPath("$.items.size()").value(3))
-                .andExpect(jsonPath("$.items[0].code").value(plantOne.getCode()))
-                .andExpect(jsonPath("$.items[1].code").value(plantThree.getCode()))
-                .andExpect(jsonPath("$.items[2].code").value(plantTwo.getCode()));
+                .andExpect(jsonPath("$.items[0].providerCode").value(plantOne.getProviderCode()))
+                .andExpect(jsonPath("$.items[1].providerCode").value(plantThree.getProviderCode()))
+                .andExpect(jsonPath("$.items[2].providerCode").value(plantTwo.getProviderCode()));
     }
 
     @Test
@@ -318,19 +318,19 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
         Plant plantOne = PlantMother.random(supplyOne)
-                .withCode("TS-456789")
+                .withProviderCode("TS-456789")
                 .withName("Plant One")
                 .withTotalPower(60D)
                 .build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
         Plant plantTwo = PlantMother.random(supplyOne)
-                .withCode("TS-123456")
+                .withProviderCode("TS-123456")
                 .withName("Plant Two")
                 .withTotalPower(60D)
                 .build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
         Plant plantThree = PlantMother.random(supplyTwo)
-                .withCode("TS-789456")
+                .withProviderCode("TS-789456")
                 .withName("Plant Three")
                 .withTotalPower(30D)
                 .build();
@@ -341,7 +341,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         mockMvc.perform(get(URL)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .queryParam("sort", "totalPower,asc")
-                        .queryParam("sort", "code,asc"))
+                        .queryParam("sort", "providerCode,asc"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.size").value("20"))
@@ -349,9 +349,9 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.totalPages").value("1"))
                 .andExpect(jsonPath("$.number").value("0"))
                 .andExpect(jsonPath("$.items.size()").value(3))
-                .andExpect(jsonPath("$.items[0].code").value(plantThree.getCode()))
-                .andExpect(jsonPath("$.items[1].code").value(plantTwo.getCode()))
-                .andExpect(jsonPath("$.items[2].code").value(plantOne.getCode()));
+                .andExpect(jsonPath("$.items[0].providerCode").value(plantThree.getProviderCode()))
+                .andExpect(jsonPath("$.items[1].providerCode").value(plantTwo.getProviderCode()))
+                .andExpect(jsonPath("$.items[2].providerCode").value(plantOne.getProviderCode()));
     }
 
     @Test
@@ -367,19 +367,19 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
         Plant plantOne = PlantMother.random(supplyOne)
-                .withCode("TS-456789")
+                .withProviderCode("TS-456789")
                 .withName("Plant One")
                 .withTotalPower(60D)
                 .build();
         createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
         Plant plantTwo = PlantMother.random(supplyOne)
-                .withCode("TS-123456")
+                .withProviderCode("TS-123456")
                 .withName("Plant Two")
                 .withTotalPower(60D)
                 .build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
         Plant plantThree = PlantMother.random(supplyTwo)
-                .withCode("TS-789456")
+                .withProviderCode("TS-789456")
                 .withName("Plant Three")
                 .withTotalPower(30D)
                 .build();
@@ -399,7 +399,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.totalPages").value("3"))
                 .andExpect(jsonPath("$.number").value("1"))
                 .andExpect(jsonPath("$.items.size()").value(1))
-                .andExpect(jsonPath("$.items[0].code").value(plantThree.getCode()));
+                .andExpect(jsonPath("$.items[0].providerCode").value(plantThree.getProviderCode()));
     }
 
     @Test
@@ -409,7 +409,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
         createUserRepository.create(user);
         Supply supply = SupplyMother.random().build();
         supply = createSupplyRepository.create(supply, UserId.of(user.getId()));
-        Plant plant = PlantMother.random(supply).withCode("TS-456789").build();
+        Plant plant = PlantMother.random(supply).withProviderCode("TS-456789").build();
         createPlantRepository.create(plant, SupplyId.of(supply.getId()));
 
         // A regular (non-admin) member of the plant's community can list its plants
@@ -421,7 +421,7 @@ class GetAllPlantsControllerTest extends BaseControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalElements").value("1"))
                 .andExpect(jsonPath("$.items.size()").value(1))
-                .andExpect(jsonPath("$.items[0].code").value(plant.getCode()));
+                .andExpect(jsonPath("$.items[0].providerCode").value(plant.getProviderCode()));
     }
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantByIdControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantByIdControllerTest.java
@@ -58,7 +58,7 @@ class GetPlantByIdControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(plant.getId().toString()))
-                .andExpect(jsonPath("$.code").value(plant.getCode()))
+                .andExpect(jsonPath("$.providerCode").value(plant.getProviderCode()))
                 .andExpect(jsonPath("$.name").value(plant.getName()))
                 .andExpect(jsonPath("$.address").value(plant.getAddress()))
                 .andExpect(jsonPath("$.description").value(plant.getDescription()))
@@ -135,7 +135,7 @@ class GetPlantByIdControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(plant.getId().toString()))
-                .andExpect(jsonPath("$.code").value(plant.getCode()));
+                .andExpect(jsonPath("$.providerCode").value(plant.getProviderCode()));
     }
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantRepositoryDatabaseIntegrationTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantRepositoryDatabaseIntegrationTest.java
@@ -86,7 +86,7 @@ class GetPlantRepositoryDatabaseIntegrationTest extends BaseIntegrationTest {
 
         assertTrue(result.isPresent());
         assertEquals(plant.getId(), result.get().getId());
-        assertEquals(plant.getCode(), result.get().getCode());
+        assertEquals(plant.getProviderCode(), result.get().getProviderCode());
     }
 
     @Test
@@ -160,7 +160,7 @@ class GetPlantRepositoryDatabaseIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void testFindPlantCodesByCommunityReturnsCodesOfPlantsOfThatCommunity() {
+    void testFindPlantProviderCodesByCommunityReturnsCodesOfPlantsOfThatCommunity() {
 
         Community community = createCommunityRepository.create(CommunityMother.random().build());
         Community otherCommunity = createCommunityRepository.create(CommunityMother.random().build());
@@ -177,18 +177,18 @@ class GetPlantRepositoryDatabaseIntegrationTest extends BaseIntegrationTest {
         createPlantRepository.create(PlantMother.random(supplyInOtherCommunity).build(),
                 SupplyId.of(supplyInOtherCommunity.getId()));
 
-        List<String> codes = getPlantRepositoryDatabase.findPlantCodesByCommunity(community.getId());
+        List<String> codes = getPlantRepositoryDatabase.findPlantProviderCodesByCommunity(community.getId());
 
         assertEquals(1, codes.size());
-        assertTrue(codes.contains(plantInCommunity.getCode()));
+        assertTrue(codes.contains(plantInCommunity.getProviderCode()));
     }
 
     @Test
-    void testFindPlantCodesByCommunityReturnsEmptyWhenCommunityHasNoPlants() {
+    void testFindPlantProviderCodesByCommunityReturnsEmptyWhenCommunityHasNoPlants() {
 
         Community community = createCommunityRepository.create(CommunityMother.random().build());
 
-        List<String> codes = getPlantRepositoryDatabase.findPlantCodesByCommunity(community.getId());
+        List<String> codes = getPlantRepositoryDatabase.findPlantProviderCodesByCommunity(community.getId());
 
         assertTrue(codes.isEmpty());
     }
@@ -216,7 +216,7 @@ class GetPlantRepositoryDatabaseIntegrationTest extends BaseIntegrationTest {
         assertEquals(1, codes.size());
         // The CUPS (supply code) is returned, not the plant/station code.
         assertTrue(codes.contains(supplyInCommunity.getCode()));
-        assertFalse(codes.contains(plantInCommunity.getCode()));
+        assertFalse(codes.contains(plantInCommunity.getProviderCode()));
         assertFalse(codes.contains(supplyInOtherCommunity.getCode()));
     }
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantControllerTest.java
@@ -55,14 +55,14 @@ class UpdatePlantControllerTest extends BaseControllerTest {
         Supply supplyTwo = SupplyMother.random().build();
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         plantOne = createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
 
         String authHeader = loginAsCommunityAdmin(DEFAULT_COMMUNITY_ID);
 
         // Modify data of the plant
         UpdatePlantBody plantModified = new UpdatePlantBody();
-        plantModified.setCode("TS-234123");
+        plantModified.setProviderCode("TS-234123");
         plantModified.setSupplyCode(supplyTwo.getCode());
         plantModified.setName("Main plant");
         plantModified.setAddress("Fake Street 666");
@@ -80,7 +80,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(plantOne.getId().toString()))
-                .andExpect(jsonPath("$.code").value(plantModified.getCode()))
+                .andExpect(jsonPath("$.providerCode").value(plantModified.getProviderCode()))
                 .andExpect(jsonPath("$.supply.code").value(plantModified.getSupplyCode()))
                 .andExpect(jsonPath("$.name").value(plantModified.getName()))
                 .andExpect(jsonPath("$.description").value(plantModified.getDescription()))
@@ -103,15 +103,15 @@ class UpdatePlantControllerTest extends BaseControllerTest {
         Supply supplyTwo = SupplyMother.random().build();
         supplyTwo = createSupplyRepository.create(supplyTwo, UserId.of(userTwo.getId()));
 
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         plantOne = createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
-        Plant plantTwo = PlantMother.random(supplyOne).withCode("TS-123456").build();
+        Plant plantTwo = PlantMother.random(supplyOne).withProviderCode("TS-123456").build();
         createPlantRepository.create(plantTwo, SupplyId.of(supplyOne.getId()));
-        Plant plantThree = PlantMother.random(supplyTwo).withCode("TS-789456").build();
+        Plant plantThree = PlantMother.random(supplyTwo).withProviderCode("TS-789456").build();
         createPlantRepository.create(plantThree, SupplyId.of(supplyTwo.getId()));
 
         UpdatePlantBody plantModified = new UpdatePlantBody();
-        plantModified.setCode("TS-234123");
+        plantModified.setProviderCode("TS-234123");
         plantModified.setName("Main plant");
         plantModified.setAddress("Fake Street 666");
         plantModified.setTotalPower(25.6D);
@@ -126,7 +126,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(plantOne.getId().toString()))
-                .andExpect(jsonPath("$.code").value(plantModified.getCode()))
+                .andExpect(jsonPath("$.providerCode").value(plantModified.getProviderCode()))
                 .andExpect(jsonPath("$.supply.code").value(plantModified.getSupplyCode()))
                 .andExpect(jsonPath("$.name").value(plantModified.getName()))
                 .andExpect(jsonPath("$.description").isEmpty())
@@ -143,7 +143,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
         final String plantId = UUID.randomUUID().toString();
 
         UpdatePlantBody plantModified = new UpdatePlantBody();
-        plantModified.setCode("TS-234123");
+        plantModified.setProviderCode("TS-234123");
         plantModified.setName("Main plant");
         plantModified.setAddress("Fake Street 666");
         plantModified.setTotalPower(25.6D);
@@ -170,13 +170,13 @@ class UpdatePlantControllerTest extends BaseControllerTest {
         supplyOne = createSupplyRepository.create(supplyOne, UserId.of(userOne.getId()));
 
         // Create three supplies
-        Plant plantOne = PlantMother.random(supplyOne).withCode("TS-456789").build();
+        Plant plantOne = PlantMother.random(supplyOne).withProviderCode("TS-456789").build();
         plantOne = createPlantRepository.create(plantOne, SupplyId.of(supplyOne.getId()));
 
         String authHeader = loginAsDefaultPlatformAdmin();
 
         UpdatePlantBody plantModified = new UpdatePlantBody();
-        plantModified.setCode("TS-234123");
+        plantModified.setProviderCode("TS-234123");
         plantModified.setName("Main plant");
         plantModified.setAddress("Fake Street 666");
         plantModified.setTotalPower(25.6D);
@@ -201,7 +201,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
         final String body = """
                         {
                           "unknown": 1,
-                          "code": "TS-234123",
+                          "providerCode": "TS-234123",
                           "name": "Main plant",
                           "address": "Fake Street 666",
                           "totalPower": "25.6"
@@ -255,21 +255,21 @@ class UpdatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                                 {
-                                  "code": "TS-234123",
+                                  "providerCode": "TS-234123",
                                   "address": "Fake Street 666",
                                   "totalPower": "25.6"
                                 }
                         """,
                 """
                                 {
-                                  "code": "TS-234123",
+                                  "providerCode": "TS-234123",
                                   "name": "Main plant",
                                   "totalPower": "25.6"
                                 }
                         """,
                 """
                                 {
-                                  "code": "TS-234123",
+                                  "providerCode": "TS-234123",
                                   "name": "Main plant",
                                   "address": "Fake Street 666",
                                 }
@@ -299,7 +299,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
     static List<String> getBodyWithInvalidFormatValues() {
         return List.of("""
                             {
-                              "code": "TS-1234124",
+                              "providerCode": "TS-1234124",
                               "name": "Plant one",
                               "personalId": "12345678Z",
                               "address": "Fake Street 123",
@@ -309,7 +309,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                             {
-                              "code": "TS-1234124",
+                              "providerCode": "TS-1234124",
                               "name": "Plant one",
                               "personalId": "12345678Z",
                               "address": "Fake Street 123",
@@ -319,7 +319,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
                         """,
                 """
                             {
-                              "code": "TS-1234124",
+                              "providerCode": "TS-1234124",
                               "name": "Plant one",
                               "personalId": "12345678Z",
                               "address": "Fake Street 123",
@@ -383,7 +383,7 @@ class UpdatePlantControllerTest extends BaseControllerTest {
         Supply supplyTwo = SupplyMother.random().build();
 
         UpdatePlantBody plantModified = new UpdatePlantBody();
-        plantModified.setCode("TS-234123");
+        plantModified.setProviderCode("TS-234123");
         plantModified.setSupplyCode(supplyTwo.getCode());
         plantModified.setName("Main plant");
         plantModified.setAddress("Fake Street 666");


### PR DESCRIPTION
## Summary

- Renames `plant.code` → `plant.providerCode` throughout the codebase: the `plants.code` Postgres column (new, rollback-tested Liquibase changeset), `PlantEntity`/`Plant`, repositories, mappers, the Huawei REST client and InfluxDB integration. The field is the plant identifier assigned by the inverter provider (currently Huawei) and is used verbatim as the `station_code` InfluxDB tag — it is not a CUPS/CAU, a distinction that was previously lost to a naming collision and caused a real mistake during an architecture review.
- **Breaking API change (intentional):** the wire contract changes too — `code` → `providerCode` on `CreatePlantBody`/`UpdatePlantBody`/`PlantResponse`, `sort=code` → `sort=providerCode` on `GET /plants`, and `plantCode` → `plantProviderCode` on the Huawei sync request bodies. `conluz-web` needs a matching update.
- Renames `PlantCode` → `PlantProviderCode` and `PlantNotFoundException.code` → `providerCode` for consistency with the rest of the rename.
- Adds documentation of the field's meaning in four places: the Liquibase changeset `remarks`, the JPA entity, the domain Javadoc, and `@Schema(description = ...)` on the three REST DTOs (so it reaches the frontend via OpenAPI/Orval).

## Test plan

- [x] `./gradlew test` — full suite green, including ArchUnit and Testcontainers integration tests
- [x] Generated OpenAPI doc inspected directly (no `api-docs.json` is committed in this repo) — `providerCode`/`plantProviderCode` appear exactly where expected, nothing else changed
- [x] Liquibase rollback exercised against a Testcontainers Postgres — `provider_code` correctly reverts to `code`
- [ ] `conluz-web` update to match the renamed JSON fields and sort param (follow-up, not in this PR)