### PR TITLE
Feature/conluz 208

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/SupplyPartitionCoefficient.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/SupplyPartitionCoefficient.java
@@ -8,6 +8,8 @@ public class SupplyPartitionCoefficient {
 
     private final UUID id;
     private final UUID supplyId;
+    private final UUID plantId;
+    private final UUID sharingAgreementId;
     private final BigDecimal coefficient;
     private final Instant validFrom;
     private final Instant validTo;
@@ -16,6 +18,8 @@ public class SupplyPartitionCoefficient {
     private SupplyPartitionCoefficient(Builder builder) {
         this.id = builder.id;
         this.supplyId = builder.supplyId;
+        this.plantId = builder.plantId;
+        this.sharingAgreementId = builder.sharingAgreementId;
         this.coefficient = builder.coefficient;
         this.validFrom = builder.validFrom;
         this.validTo = builder.validTo;
@@ -28,6 +32,14 @@ public class SupplyPartitionCoefficient {
 
     public UUID getSupplyId() {
         return supplyId;
+    }
+
+    public UUID getPlantId() {
+        return plantId;
+    }
+
+    public UUID getSharingAgreementId() {
+        return sharingAgreementId;
     }
 
     public BigDecimal getCoefficient() {
@@ -53,6 +65,8 @@ public class SupplyPartitionCoefficient {
     public static class Builder {
         private UUID id;
         private UUID supplyId;
+        private UUID plantId;
+        private UUID sharingAgreementId;
         private BigDecimal coefficient;
         private Instant validFrom;
         private Instant validTo;
@@ -65,6 +79,16 @@ public class SupplyPartitionCoefficient {
 
         public Builder withSupplyId(UUID supplyId) {
             this.supplyId = supplyId;
+            return this;
+        }
+
+        public Builder withPlantId(UUID plantId) {
+            this.plantId = plantId;
+            return this;
+        }
+
+        public Builder withSharingAgreementId(UUID sharingAgreementId) {
+            this.sharingAgreementId = sharingAgreementId;
             return this;
         }
 

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepository.java
@@ -20,7 +20,7 @@ public interface SupplyPartitionCoefficientRepository {
 
     SupplyPartitionCoefficient save(SupplyPartitionCoefficient coefficient);
 
-    void closeActivePeriod(UUID supplyId, Instant validTo);
+    void closeActivePeriod(UUID supplyId, UUID plantId, Instant validTo);
 
     void syncSupplyPartitionCoefficient(UUID supplyId, BigDecimal newCoefficient);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/get/GetPlantRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/get/GetPlantRepository.java
@@ -22,6 +22,13 @@ public interface GetPlantRepository {
     PagedResult<Plant> findByCommunities(PagedRequest pagedRequest, Set<UUID> communityIds);
 
     /**
+     * The single plant of a community. Relies on the one-plant-per-community invariant enforced by
+     * the phase 2d migration precondition; if that invariant is ever violated, the underlying query
+     * throws rather than silently picking one plant.
+     */
+    Optional<Plant> findByCommunityId(UUID communityId);
+
+    /**
      * Provider codes of the plants belonging to the given community. These codes match the InfluxDB
      * {@code station_code} tag, so they can be used to scope time-series production queries.
      */

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/get/GetSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/get/GetSharingAgreementRepository.java
@@ -1,0 +1,12 @@
+package org.lucoenergia.conluz.domain.production.plant.get;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetSharingAgreementRepository {
+
+    /**
+     * The id of the current PUBLISHED sharing agreement for a plant, if any.
+     */
+    Optional<UUID> findCurrentPublishedAgreementIdByPlantId(UUID plantId);
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientEntity.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientEntity.java
@@ -1,6 +1,8 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply;
 
 import jakarta.persistence.*;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -17,6 +19,14 @@ public class SupplyPartitionCoefficientEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "supply_id", nullable = false)
     private SupplyEntity supply;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_id", nullable = false)
+    private PlantEntity plant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sharing_agreement_id", nullable = false)
+    private SharingAgreementEntity sharingAgreement;
 
     @Column(name = "coefficient", nullable = false, precision = 18, scale = 6)
     private BigDecimal coefficient;
@@ -44,6 +54,22 @@ public class SupplyPartitionCoefficientEntity {
 
     public void setSupply(SupplyEntity supply) {
         this.supply = supply;
+    }
+
+    public PlantEntity getPlant() {
+        return plant;
+    }
+
+    public void setPlant(PlantEntity plant) {
+        this.plant = plant;
+    }
+
+    public SharingAgreementEntity getSharingAgreement() {
+        return sharingAgreement;
+    }
+
+    public void setSharingAgreement(SharingAgreementEntity sharingAgreement) {
+        this.sharingAgreement = sharingAgreement;
     }
 
     public BigDecimal getCoefficient() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientEntityMapper.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientEntityMapper.java
@@ -13,6 +13,8 @@ public class SupplyPartitionCoefficientEntityMapper
         return new SupplyPartitionCoefficient.Builder()
                 .withId(entity.getId())
                 .withSupplyId(entity.getSupply().getId())
+                .withPlantId(entity.getPlant().getId())
+                .withSharingAgreementId(entity.getSharingAgreement().getId())
                 .withCoefficient(entity.getCoefficient())
                 .withValidFrom(entity.getValidFrom())
                 .withValidTo(entity.getValidTo())

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientJpaRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientJpaRepository.java
@@ -15,6 +15,12 @@ public interface SupplyPartitionCoefficientJpaRepository extends JpaRepository<S
     @Query("SELECT e FROM SupplyPartitionCoefficientEntity e WHERE e.supply.id = :supplyId AND e.validTo IS NULL")
     Optional<SupplyPartitionCoefficientEntity> findActiveBySupplyId(@Param("supplyId") UUID supplyId);
 
+    @Query("SELECT e FROM SupplyPartitionCoefficientEntity e WHERE e.supply.id = :supplyId " +
+            "AND e.plant.id = :plantId AND e.validTo IS NULL")
+    Optional<SupplyPartitionCoefficientEntity> findActiveBySupplyIdAndPlantId(
+            @Param("supplyId") UUID supplyId,
+            @Param("plantId") UUID plantId);
+
     // valid_from inclusive, valid_to exclusive
     @Query("SELECT e FROM SupplyPartitionCoefficientEntity e WHERE e.supply.id = :supplyId " +
             "AND e.validFrom <= :timestamp AND (e.validTo IS NULL OR e.validTo > :timestamp)")
@@ -40,6 +46,6 @@ public interface SupplyPartitionCoefficientJpaRepository extends JpaRepository<S
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE SupplyPartitionCoefficientEntity e SET e.validTo = :validTo " +
-            "WHERE e.supply.id = :supplyId AND e.validTo IS NULL")
-    void closeActivePeriod(@Param("supplyId") UUID supplyId, @Param("validTo") Instant validTo);
+            "WHERE e.supply.id = :supplyId AND e.plant.id = :plantId AND e.validTo IS NULL")
+    void closeActivePeriod(@Param("supplyId") UUID supplyId, @Param("plantId") UUID plantId, @Param("validTo") Instant validTo);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/PartitionCoefficientServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/PartitionCoefficientServiceImpl.java
@@ -1,11 +1,15 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply.partitioncoefficient;
 
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.PartitionCoefficientService;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficientNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.get.GetPlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,11 +27,17 @@ public class PartitionCoefficientServiceImpl implements PartitionCoefficientServ
 
     private final SupplyPartitionCoefficientRepository repository;
     private final GetSupplyRepository getSupplyRepository;
+    private final GetPlantRepository getPlantRepository;
+    private final GetSharingAgreementRepository getSharingAgreementRepository;
 
     public PartitionCoefficientServiceImpl(SupplyPartitionCoefficientRepository repository,
-                                           GetSupplyRepository getSupplyRepository) {
+                                           GetSupplyRepository getSupplyRepository,
+                                           GetPlantRepository getPlantRepository,
+                                           GetSharingAgreementRepository getSharingAgreementRepository) {
         this.repository = repository;
         this.getSupplyRepository = getSupplyRepository;
+        this.getPlantRepository = getPlantRepository;
+        this.getSharingAgreementRepository = getSharingAgreementRepository;
     }
 
     @Override
@@ -50,14 +60,34 @@ public class PartitionCoefficientServiceImpl implements PartitionCoefficientServ
     @Override
     public SupplyPartitionCoefficient registerCoefficientChange(UUID supplyId, BigDecimal newCoefficient,
                                                                 Instant effectiveAt) {
-        getSupplyRepository.findById(SupplyId.of(supplyId))
+        Supply supply = getSupplyRepository.findById(SupplyId.of(supplyId))
                 .orElseThrow(() -> new SupplyNotFoundException(SupplyId.of(supplyId)));
 
-        repository.closeActivePeriod(supplyId, effectiveAt);
+        // INTERIM (phase 2d): plant and sharing-agreement are inferred here because
+        // neither the single-supply endpoint nor the bulk-import path carries that
+        // context yet. Phase 3 (distributor-file-driven agreement creation) removes
+        // this inference entirely: the caller will pass plantId/sharingAgreementId
+        // explicitly and this block should be deleted then.
+        UUID communityId = supply.getCommunity().getId();
+        Plant plant = getPlantRepository.findByCommunityId(communityId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "No plant for community " + communityId + " during interim phase-2d coefficient " +
+                        "resolution; this is guaranteed by the phase-2d migration precondition and should be unreachable."));
+        UUID plantId = plant.getId();
+        UUID sharingAgreementId = getSharingAgreementRepository
+                .findCurrentPublishedAgreementIdByPlantId(plantId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "No PUBLISHED sharing agreement for plant " + plantId + " during interim phase-2d " +
+                        "coefficient resolution; every plant with coefficients gets a synthetic PUBLISHED " +
+                        "agreement in the phase-2d migration backfill, so this should be unreachable."));
+
+        repository.closeActivePeriod(supplyId, plantId, effectiveAt);
 
         SupplyPartitionCoefficient newPeriod = new SupplyPartitionCoefficient.Builder()
                 .withId(UUID.randomUUID())
                 .withSupplyId(supplyId)
+                .withPlantId(plantId)
+                .withSharingAgreementId(sharingAgreementId)
                 .withCoefficient(newCoefficient)
                 .withValidFrom(effectiveAt)
                 .withValidTo(null)
@@ -98,6 +128,8 @@ public class PartitionCoefficientServiceImpl implements PartitionCoefficientServ
         return new SupplyPartitionCoefficient.Builder()
                 .withId(period.getId())
                 .withSupplyId(period.getSupplyId())
+                .withPlantId(period.getPlantId())
+                .withSharingAgreementId(period.getSharingAgreementId())
                 .withCoefficient(period.getCoefficient())
                 .withValidFrom(clippedFrom)
                 .withValidTo(clippedTo)

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabase.java
@@ -3,12 +3,18 @@ package org.lucoenergia.conluz.infrastructure.admin.supply.partitioncoefficient;
 import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.shared.PlantId;
 import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientEntity;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientEntityMapper;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientJpaRepository;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
@@ -28,14 +34,20 @@ public class SupplyPartitionCoefficientRepositoryDatabase implements SupplyParti
 
     private final SupplyPartitionCoefficientJpaRepository jpaRepository;
     private final SupplyRepository supplyRepository;
+    private final PlantRepository plantRepository;
+    private final SharingAgreementRepository sharingAgreementRepository;
     private final SupplyPartitionCoefficientEntityMapper mapper;
 
     public SupplyPartitionCoefficientRepositoryDatabase(
             SupplyPartitionCoefficientJpaRepository jpaRepository,
             SupplyRepository supplyRepository,
+            PlantRepository plantRepository,
+            SharingAgreementRepository sharingAgreementRepository,
             SupplyPartitionCoefficientEntityMapper mapper) {
         this.jpaRepository = jpaRepository;
         this.supplyRepository = supplyRepository;
+        this.plantRepository = plantRepository;
+        this.sharingAgreementRepository = sharingAgreementRepository;
         this.mapper = mapper;
     }
 
@@ -73,10 +85,17 @@ public class SupplyPartitionCoefficientRepositoryDatabase implements SupplyParti
     public SupplyPartitionCoefficient save(SupplyPartitionCoefficient coefficient) {
         SupplyEntity supplyEntity = supplyRepository.findById(coefficient.getSupplyId())
                 .orElseThrow(() -> new SupplyNotFoundException(SupplyId.of(coefficient.getSupplyId())));
+        PlantEntity plantEntity = plantRepository.findById(coefficient.getPlantId())
+                .orElseThrow(() -> new PlantNotFoundException(PlantId.of(coefficient.getPlantId())));
+        SharingAgreementEntity sharingAgreementEntity = sharingAgreementRepository.findById(coefficient.getSharingAgreementId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Sharing agreement " + coefficient.getSharingAgreementId() + " not found while saving a coefficient"));
 
         SupplyPartitionCoefficientEntity entity = new SupplyPartitionCoefficientEntity();
         entity.setId(coefficient.getId());
         entity.setSupply(supplyEntity);
+        entity.setPlant(plantEntity);
+        entity.setSharingAgreement(sharingAgreementEntity);
         entity.setCoefficient(coefficient.getCoefficient());
         entity.setValidFrom(coefficient.getValidFrom());
         entity.setValidTo(coefficient.getValidTo());
@@ -86,10 +105,10 @@ public class SupplyPartitionCoefficientRepositoryDatabase implements SupplyParti
     }
 
     @Override
-    public void closeActivePeriod(UUID supplyId, Instant validTo) {
-        Optional<SupplyPartitionCoefficientEntity> result = jpaRepository.findActiveBySupplyId(supplyId);
+    public void closeActivePeriod(UUID supplyId, UUID plantId, Instant validTo) {
+        Optional<SupplyPartitionCoefficientEntity> result = jpaRepository.findActiveBySupplyIdAndPlantId(supplyId, plantId);
         if (result.isEmpty()) {
-            LOGGER.debug("No active coefficient found for supply {}", supplyId);
+            LOGGER.debug("No active coefficient found for supply {} and plant {}", supplyId, plantId);
             return;
         }
         SupplyPartitionCoefficientEntity activeCoefficient = result.get();

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantRepository.java
@@ -26,6 +26,14 @@ public interface PlantRepository extends JpaRepository<PlantEntity, UUID> {
     Page<PlantEntity> findBySupplyCommunityIdIn(Collection<UUID> communityIds, Pageable pageable);
 
     /**
+     * The single plant whose supply belongs to the given community. Throws
+     * {@link org.springframework.dao.IncorrectResultSizeDataAccessException} if more than one plant
+     * matches, which should never happen under the one-plant-per-community invariant relied on by
+     * the phase 2d migration.
+     */
+    Optional<PlantEntity> findBySupplyCommunityId(UUID communityId);
+
+    /**
      * Provider codes of the plants whose supply belongs to the given community. These codes match
      * the {@code station_code} tag used in InfluxDB, so they can be used to scope time-series queries.
      */

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/SharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/SharingAgreementRepository.java
@@ -1,0 +1,12 @@
+package org.lucoenergia.conluz.infrastructure.production.plant;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SharingAgreementRepository extends JpaRepository<SharingAgreementEntity, UUID> {
+
+    Optional<SharingAgreementEntity> findFirstByPlantIdAndStatusOrderByCreatedAtDesc(
+            UUID plantId, SharingAgreementStatus status);
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantRepositoryDatabase.java
@@ -58,6 +58,11 @@ public class GetPlantRepositoryDatabase implements GetPlantRepository {
     }
 
     @Override
+    public Optional<Plant> findByCommunityId(UUID communityId) {
+        return plantRepository.findBySupplyCommunityId(communityId).map(plantEntityMapper::map);
+    }
+
+    @Override
     public List<String> findPlantProviderCodesByCommunity(UUID communityId) {
         return plantRepository.findProviderCodesByCommunityId(communityId);
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetSharingAgreementRepositoryDatabase.java
@@ -1,0 +1,30 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.get;
+
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Transactional
+@Repository
+public class GetSharingAgreementRepositoryDatabase implements GetSharingAgreementRepository {
+
+    private final SharingAgreementRepository sharingAgreementRepository;
+
+    public GetSharingAgreementRepositoryDatabase(SharingAgreementRepository sharingAgreementRepository) {
+        this.sharingAgreementRepository = sharingAgreementRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<UUID> findCurrentPublishedAgreementIdByPlantId(UUID plantId) {
+        return sharingAgreementRepository
+                .findFirstByPlantIdAndStatusOrderByCreatedAtDesc(plantId, SharingAgreementStatus.PUBLISHED)
+                .map(SharingAgreementEntity::getId);
+    }
+}

--- a/src/main/resources/db/liquibase/changelogs/add_plant_and_sharing_agreement_to_supply_partition_coefficient.xml
+++ b/src/main/resources/db/liquibase/changelogs/add_plant_and_sharing_agreement_to_supply_partition_coefficient.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- Guards: "every community that currently owns a supply_partition_coefficient row has
+         exactly one plant". This starts from supply_partition_coefficient (the table the backfill
+         in this phase actually walks), not from plants, on purpose: grouping from plants would
+         silently skip any community that owns coefficients but has zero plants (such a community
+         never appears in a GROUP BY over plants), letting it sail through here only to fail the
+         addNotNullConstraint changeset later, after the synthetic-agreement backfill has already
+         written data. The guarded set must match the mutated set. -->
+    <changeSet id="add_plant_and_sharing_agreement_to_supply_partition_coefficient" author="Víctor Cañizares">
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM (
+                    SELECT owner.community_id
+                    FROM supply_partition_coefficient spc
+                    JOIN supplies owner ON owner.id = spc.supply_id
+                    GROUP BY owner.community_id
+                ) communities_with_coefficients
+                LEFT JOIN (
+                    SELECT ps.community_id, count(*) AS plant_count
+                    FROM plants p
+                    JOIN supplies ps ON ps.id = p.supply_id
+                    GROUP BY ps.community_id
+                ) plant_counts ON plant_counts.community_id = communities_with_coefficients.community_id
+                WHERE COALESCE(plant_counts.plant_count, 0) &lt;&gt; 1
+            </sqlCheck>
+        </preConditions>
+        <addColumn tableName="supply_partition_coefficient">
+            <column name="plant_id" type="UUID" remarks="The plant this coefficient participates in. Nullable here, made NOT NULL by make_supply_partition_coefficient_plant_and_sharing_agreement_not_null.xml once backfilled.">
+                <constraints nullable="true" foreignKeyName="supply_partition_coefficient_plant_id_fk"
+                             referencedTableName="plants" referencedColumnNames="id"/>
+            </column>
+            <column name="sharing_agreement_id" type="UUID" remarks="The agreement that authored this coefficient. Nullable here for the same reason as plant_id.">
+                <constraints nullable="true" foreignKeyName="supply_partition_coefficient_sharing_agreement_id_fk"
+                             referencedTableName="sharing_agreement" referencedColumnNames="id"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="supply_partition_coefficient" columnName="plant_id"/>
+            <dropColumn tableName="supply_partition_coefficient" columnName="sharing_agreement_id"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelogs/add_supply_partition_coefficient_no_overlapping_exclusion_constraint.xml
+++ b/src/main/resources/db/liquibase/changelogs/add_supply_partition_coefficient_no_overlapping_exclusion_constraint.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- Forbids overlapping [valid_from, valid_to) periods for the same (plant_id, supply_id), using
+         a GiST exclusion constraint (btree_gist supplies GiST support for the plain equality columns).
+
+         '[)', half-open: valid_to is derived: the end of supply S's coefficient in agreement N is
+         the valid_from of S in agreement N+1, so consecutive rows share a boundary instant. '[]'
+         would treat that shared instant as overlap and reject every superseding agreement; '[)' makes
+         adjacent rows non-overlapping.
+
+         WHERE (valid_from IS NOT NULL), partial: valid_from is still NOT NULL on every row in this
+         phase, so this predicate is currently always true and has no observable effect today. It is
+         included anyway because it future-proofs the constraint against an anticipated later
+         relaxation of valid_from's nullability (pending, not-yet-activated rows), so a future phase
+         does not need to touch this exclusion constraint again. Do not remove it as dead code. -->
+    <changeSet id="add_supply_partition_coefficient_no_overlapping_exclusion_constraint" author="Víctor Cañizares">
+        <!-- Defense in depth: the strictly-stronger overlap check this constraint enforces (any
+             overlap, not just a second open-ended row) must be proven against real data before this
+             changeset ever runs in an environment with existing coefficients. See the phase 2d report
+             for the manual diagnostic run against production. This precondition re-checks the same
+             condition, precisely (plant_id is populated and NOT NULL by this point in the chain), so
+             the migration HALTs cleanly instead of failing mid-ALTER TABLE if data drifted. -->
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT count(*)
+                FROM supply_partition_coefficient a
+                JOIN supply_partition_coefficient b
+                  ON a.plant_id = b.plant_id AND a.supply_id = b.supply_id AND a.id &lt; b.id
+                 AND a.valid_from IS NOT NULL AND b.valid_from IS NOT NULL
+                 AND tstzrange(a.valid_from, a.valid_to, '[)') &amp;&amp; tstzrange(b.valid_from, b.valid_to, '[)')
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            ALTER TABLE supply_partition_coefficient ADD CONSTRAINT no_overlapping_coefficients
+              EXCLUDE USING gist (plant_id WITH =, supply_id WITH =,
+                                  tstzrange(valid_from, valid_to, '[)') WITH &amp;&amp;)
+              WHERE (valid_from IS NOT NULL);
+        </sql>
+        <rollback>
+            <sql>ALTER TABLE supply_partition_coefficient DROP CONSTRAINT no_overlapping_coefficients;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelogs/backfill_plant_and_sharing_agreement_on_supply_partition_coefficient.xml
+++ b/src/main/resources/db/liquibase/changelogs/backfill_plant_and_sharing_agreement_on_supply_partition_coefficient.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- Attaches every existing coefficient row to the plant of its supply's community and to the
+         synthetic agreement created for that plant by the previous changeset. Same community-derived
+         plant lookup as that changeset, since plant_id is still NULL on every row at this point. -->
+    <changeSet id="backfill_plant_and_sharing_agreement_on_supply_partition_coefficient" author="Víctor Cañizares">
+        <sql>
+            UPDATE supply_partition_coefficient spc
+            SET plant_id = plant_lookup.plant_id,
+                sharing_agreement_id = sa.id
+            FROM (
+                SELECT s.id AS supply_id, p.id AS plant_id
+                FROM supplies s
+                JOIN supplies plant_supply ON plant_supply.community_id = s.community_id
+                JOIN plants p ON p.supply_id = plant_supply.id
+            ) plant_lookup
+            JOIN sharing_agreement sa
+              ON sa.plant_id = plant_lookup.plant_id
+             AND sa.name = '[phase-2d-migration] Synthetic agreement (pre-model coefficients)'
+            WHERE spc.supply_id = plant_lookup.supply_id;
+        </sql>
+        <rollback>
+            <sql>UPDATE supply_partition_coefficient SET plant_id = NULL, sharing_agreement_id = NULL;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelogs/backfill_synthetic_sharing_agreement_for_supply_partition_coefficient.xml
+++ b/src/main/resources/db/liquibase/changelogs/backfill_synthetic_sharing_agreement_for_supply_partition_coefficient.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- One PUBLISHED, created_by=NULL (system-created, see create_table_sharing_agreement.xml)
+         sharing_agreement per plant that currently has supply_partition_coefficient rows, so the
+         following changeset can attach every existing coefficient to a real agreement.
+
+         plant_id does not exist on supply_partition_coefficient yet at this point in the chain, so
+         the plant is derived transitively: plants -> supplies (the plant's own supply) ->
+         community_id -> supplies (the coefficient-owning supplies) -> supply_partition_coefficient.
+
+         The `name` value below is a reserved sentinel, not a description: it is also used by this
+         changeset's rollback and by backfill_plant_and_sharing_agreement_on_supply_partition_coefficient.xml
+         to identify exactly these rows. No future agreement-creation code (including phase 5) may
+         reuse this exact string. -->
+    <changeSet id="backfill_synthetic_sharing_agreement_for_supply_partition_coefficient" author="Víctor Cañizares">
+        <sql>
+            INSERT INTO sharing_agreement (id, plant_id, name, notes, status, installed_power_kw, created_at, created_by)
+            SELECT gen_random_uuid(),
+                   plant_id,
+                   '[phase-2d-migration] Synthetic agreement (pre-model coefficients)',
+                   'Synthetic agreement created by the phase 2d migration to anchor supply_partition_coefficient rows that predate the sharing-agreement model. Not authored by any user -- see create_table_sharing_agreement.xml for why created_by is NULL rather than a synthetic system user.',
+                   'PUBLISHED',
+                   total_power::numeric,
+                   NOW(),
+                   NULL
+            FROM (
+                SELECT DISTINCT p.id AS plant_id, p.total_power
+                FROM plants p
+                JOIN supplies plant_supply ON plant_supply.id = p.supply_id
+                JOIN supplies coefficient_supply ON coefficient_supply.community_id = plant_supply.community_id
+                JOIN supply_partition_coefficient spc ON spc.supply_id = coefficient_supply.id
+            ) plants_with_coefficients;
+        </sql>
+        <rollback>
+            <sql>
+                DELETE FROM sharing_agreement
+                WHERE created_by IS NULL
+                  AND status = 'PUBLISHED'
+                  AND name = '[phase-2d-migration] Synthetic agreement (pre-model coefficients)';
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelogs/drop_supply_partition_coefficient_one_active_index.xml
+++ b/src/main/resources/db/liquibase/changelogs/drop_supply_partition_coefficient_one_active_index.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- Replaced by add_supply_partition_coefficient_no_overlapping_exclusion_constraint.xml, which
+         enforces the equivalent invariant scoped to (plant_id, supply_id) instead of supply_id alone,
+         now that a supply may have an active coefficient in more than one plant at once. -->
+    <changeSet id="drop_supply_partition_coefficient_one_active_index" author="Víctor Cañizares">
+        <sql>DROP INDEX idx_supply_partition_coefficient_one_active;</sql>
+        <rollback>
+            <sql>
+                CREATE UNIQUE INDEX idx_supply_partition_coefficient_one_active
+                ON supply_partition_coefficient (supply_id)
+                WHERE valid_to IS NULL;
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelogs/enable_btree_gist_extension.xml
+++ b/src/main/resources/db/liquibase/changelogs/enable_btree_gist_extension.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <!-- Required by the exclusion constraint added later in this phase
+         (add_supply_partition_coefficient_no_overlapping_exclusion_constraint.xml), which needs
+         GiST support for plain equality types (UUID) via btree_gist. Not installed anywhere yet. -->
+    <changeSet id="enable_btree_gist_extension" author="Víctor Cañizares">
+        <sql>CREATE EXTENSION IF NOT EXISTS btree_gist;</sql>
+        <rollback>
+            <sql>DROP EXTENSION IF EXISTS btree_gist;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelogs/make_supply_partition_coefficient_plant_and_sharing_agreement_not_null.xml
+++ b/src/main/resources/db/liquibase/changelogs/make_supply_partition_coefficient_plant_and_sharing_agreement_not_null.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <changeSet id="make_supply_partition_coefficient_plant_and_sharing_agreement_not_null" author="Víctor Cañizares">
+        <addNotNullConstraint tableName="supply_partition_coefficient" columnName="plant_id" columnDataType="UUID"/>
+        <addNotNullConstraint tableName="supply_partition_coefficient" columnName="sharing_agreement_id" columnDataType="UUID"/>
+        <rollback>
+            <dropNotNullConstraint tableName="supply_partition_coefficient" columnName="plant_id" columnDataType="UUID"/>
+            <dropNotNullConstraint tableName="supply_partition_coefficient" columnName="sharing_agreement_id" columnDataType="UUID"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/db.changelog-main.xml
+++ b/src/main/resources/db/liquibase/db.changelog-main.xml
@@ -47,4 +47,11 @@ http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
     <include file="changelogs/create_table_sharing_agreement_file.xml" relativeToChangelogFile="true" />
     <include file="changelogs/drop_table_supplies_partitions.xml" relativeToChangelogFile="true" />
     <include file="changelogs/drop_table_sharing_agreements.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/enable_btree_gist_extension.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/add_plant_and_sharing_agreement_to_supply_partition_coefficient.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/backfill_synthetic_sharing_agreement_for_supply_partition_coefficient.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/backfill_plant_and_sharing_agreement_on_supply_partition_coefficient.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/make_supply_partition_coefficient_plant_and_sharing_agreement_not_null.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/drop_supply_partition_coefficient_one_active_index.xml" relativeToChangelogFile="true" />
+    <include file="changelogs/add_supply_partition_coefficient_no_overlapping_exclusion_constraint.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/test/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/PartitionCoefficientServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/PartitionCoefficientServiceTest.java
@@ -2,9 +2,13 @@ package org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.SupplyNotFoundException;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.get.GetPlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.shared.SupplyId;
 import org.lucoenergia.conluz.infrastructure.admin.supply.partitioncoefficient.PartitionCoefficientServiceImpl;
 
@@ -25,14 +29,21 @@ class PartitionCoefficientServiceTest {
     private PartitionCoefficientService service;
     private SupplyPartitionCoefficientRepository repository;
     private GetSupplyRepository getSupplyRepository;
+    private GetPlantRepository getPlantRepository;
+    private GetSharingAgreementRepository getSharingAgreementRepository;
 
     private static final UUID SUPPLY_ID = UUID.randomUUID();
+    private static final UUID COMMUNITY_ID = UUID.randomUUID();
+    private static final UUID PLANT_ID = UUID.randomUUID();
+    private static final UUID SHARING_AGREEMENT_ID = UUID.randomUUID();
 
     @BeforeEach
     void setUp() {
         repository = mock(SupplyPartitionCoefficientRepository.class);
         getSupplyRepository = mock(GetSupplyRepository.class);
-        service = new PartitionCoefficientServiceImpl(repository, getSupplyRepository);
+        getPlantRepository = mock(GetPlantRepository.class);
+        getSharingAgreementRepository = mock(GetSharingAgreementRepository.class);
+        service = new PartitionCoefficientServiceImpl(repository, getSupplyRepository, getPlantRepository, getSharingAgreementRepository);
     }
 
     // --- resolveCoefficient ---
@@ -153,14 +164,24 @@ class PartitionCoefficientServiceTest {
         Instant effectiveAt = Instant.parse("2025-06-01T00:00:00Z");
         BigDecimal newCoefficient = BigDecimal.valueOf(7.000000);
 
-        when(getSupplyRepository.findById(SupplyId.of(SUPPLY_ID))).thenReturn(Optional.of(mock(Supply.class)));
+        Community community = mock(Community.class);
+        when(community.getId()).thenReturn(COMMUNITY_ID);
+        Supply supply = mock(Supply.class);
+        when(supply.getCommunity()).thenReturn(community);
+        when(getSupplyRepository.findById(SupplyId.of(SUPPLY_ID))).thenReturn(Optional.of(supply));
+
+        Plant plant = mock(Plant.class);
+        when(plant.getId()).thenReturn(PLANT_ID);
+        when(getPlantRepository.findByCommunityId(COMMUNITY_ID)).thenReturn(Optional.of(plant));
+        when(getSharingAgreementRepository.findCurrentPublishedAgreementIdByPlantId(PLANT_ID))
+                .thenReturn(Optional.of(SHARING_AGREEMENT_ID));
 
         SupplyPartitionCoefficient saved = buildRecord(effectiveAt, null, newCoefficient);
         when(repository.save(any())).thenReturn(saved);
 
         SupplyPartitionCoefficient result = service.registerCoefficientChange(SUPPLY_ID, newCoefficient, effectiveAt);
 
-        verify(repository).closeActivePeriod(SUPPLY_ID, effectiveAt);
+        verify(repository).closeActivePeriod(SUPPLY_ID, PLANT_ID, effectiveAt);
         verify(repository).save(argThat(c ->
                 c.getSupplyId().equals(SUPPLY_ID)
                         && c.getCoefficient().equals(newCoefficient)

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/GetPartitionCoefficientControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/GetPartitionCoefficientControllerTest.java
@@ -10,7 +10,15 @@ import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPar
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
 import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
 import org.lucoenergia.conluz.domain.shared.UserPersonalId;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementStatus;
 import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -38,15 +46,22 @@ class GetPartitionCoefficientControllerTest extends BaseControllerTest {
     private SupplyPartitionCoefficientRepository partitionCoefficientRepository;
     @Autowired
     private GetCommunityRepository getCommunityRepository;
+    @Autowired
+    private SupplyRepository supplyJpaRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
 
     @Test
     void getHistoryReturnsAllPeriodsOrdered() throws Exception {
         String authHeader = loginAsCommunityAdmin(DEFAULT_COMMUNITY_ID);
         Supply supply = createTestSupply();
+        SharingAgreementEntity agreement = ensurePlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
-        persistCoefficient(supply.getId(), BigDecimal.valueOf(1.0), t0, t1);
-        persistCoefficient(supply.getId(), BigDecimal.valueOf(2.0), t1, null);
+        persistCoefficient(supply.getId(), agreement, BigDecimal.valueOf(1.0), t0, t1);
+        persistCoefficient(supply.getId(), agreement, BigDecimal.valueOf(2.0), t1, null);
 
         mockMvc.perform(get("/api/v1/supplies/" + supply.getId() + "/partition-coefficients")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -62,10 +77,11 @@ class GetPartitionCoefficientControllerTest extends BaseControllerTest {
     void getActiveReturnsRowWithNullValidTo() throws Exception {
         String authHeader = loginAsCommunityAdmin(DEFAULT_COMMUNITY_ID);
         Supply supply = createTestSupply();
+        SharingAgreementEntity agreement = ensurePlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
-        persistCoefficient(supply.getId(), BigDecimal.valueOf(1.0), t0, t1);
-        persistCoefficient(supply.getId(), BigDecimal.valueOf(2.0), t1, null);
+        persistCoefficient(supply.getId(), agreement, BigDecimal.valueOf(1.0), t0, t1);
+        persistCoefficient(supply.getId(), agreement, BigDecimal.valueOf(2.0), t1, null);
 
         mockMvc.perform(get("/api/v1/supplies/" + supply.getId() + "/partition-coefficients/active")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -79,10 +95,11 @@ class GetPartitionCoefficientControllerTest extends BaseControllerTest {
     void getAtTimestampReturnsCoefficientActiveAtThatInstant() throws Exception {
         String authHeader = loginAsCommunityAdmin(DEFAULT_COMMUNITY_ID);
         Supply supply = createTestSupply();
+        SharingAgreementEntity agreement = ensurePlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
-        persistCoefficient(supply.getId(), BigDecimal.valueOf(3.076300), t0, t1);
-        persistCoefficient(supply.getId(), BigDecimal.valueOf(4.000000), t1, null);
+        persistCoefficient(supply.getId(), agreement, BigDecimal.valueOf(3.076300), t0, t1);
+        persistCoefficient(supply.getId(), agreement, BigDecimal.valueOf(4.000000), t1, null);
 
         mockMvc.perform(get("/api/v1/supplies/" + supply.getId() + "/partition-coefficients/at")
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -114,10 +131,26 @@ class GetPartitionCoefficientControllerTest extends BaseControllerTest {
         return createSupplyService.create(supply, UserPersonalId.of(user.getPersonalId()), DEFAULT_COMMUNITY_ID);
     }
 
-    private void persistCoefficient(UUID supplyId, BigDecimal coefficient, Instant validFrom, Instant validTo) {
+    private SharingAgreementEntity ensurePlantAndPublishedAgreement(Supply supply) {
+        SupplyEntity supplyEntity = supplyJpaRepository.getReferenceById(supply.getId());
+        PlantEntity plant = plantRepository.save(PlantMother.randomPlantEntity().withSupply(supplyEntity).build());
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plant);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(SharingAgreementStatus.PUBLISHED);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    private void persistCoefficient(UUID supplyId, SharingAgreementEntity agreement,
+                                    BigDecimal coefficient, Instant validFrom, Instant validTo) {
         partitionCoefficientRepository.save(new SupplyPartitionCoefficient.Builder()
                 .withId(UUID.randomUUID())
                 .withSupplyId(supplyId)
+                .withPlantId(agreement.getPlant().getId())
+                .withSharingAgreementId(agreement.getId())
                 .withCoefficient(coefficient)
                 .withValidFrom(validFrom)
                 .withValidTo(validTo)

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/RegisterPartitionCoefficientControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/RegisterPartitionCoefficientControllerTest.java
@@ -8,12 +8,23 @@ import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyService;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
 import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
 import org.lucoenergia.conluz.domain.shared.UserPersonalId;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementStatus;
 import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
@@ -31,6 +42,12 @@ class RegisterPartitionCoefficientControllerTest extends BaseControllerTest {
     private CreateSupplyService createSupplyService;
     @Autowired
     private GetCommunityRepository getCommunityRepository;
+    @Autowired
+    private SupplyRepository supplyJpaRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
 
     @Test
     void registersNewCoefficientWithSumEqualToOneReturnsNoWarning() throws Exception {
@@ -141,6 +158,35 @@ class RegisterPartitionCoefficientControllerTest extends BaseControllerTest {
         User user = UserMother.randomUser();
         createUserRepository.create(user);
         Supply supply = SupplyMother.random(user).build();
-        return createSupplyService.create(supply, UserPersonalId.of(user.getPersonalId()), DEFAULT_COMMUNITY_ID);
+        Supply created = createSupplyService.create(supply, UserPersonalId.of(user.getPersonalId()), DEFAULT_COMMUNITY_ID);
+        ensurePlantAndPublishedAgreement(created);
+        return created;
+    }
+
+    /**
+     * registerCoefficientChange resolves plant/agreement from the supply's community (interim
+     * phase-2d inference), so the community needs a plant with a PUBLISHED agreement for that to
+     * succeed. Idempotent per community: only creates them the first time they're missing.
+     */
+    private void ensurePlantAndPublishedAgreement(Supply supply) {
+        PlantEntity plant = plantRepository.findBySupplyCommunityId(DEFAULT_COMMUNITY_ID)
+                .orElseGet(() -> {
+                    SupplyEntity supplyEntity = supplyJpaRepository.getReferenceById(supply.getId());
+                    return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supplyEntity).build());
+                });
+
+        boolean hasPublishedAgreement = sharingAgreementRepository
+                .findFirstByPlantIdAndStatusOrderByCreatedAtDesc(plant.getId(), SharingAgreementStatus.PUBLISHED)
+                .isPresent();
+        if (!hasPublishedAgreement) {
+            SharingAgreementEntity agreement = new SharingAgreementEntity();
+            agreement.setId(UUID.randomUUID());
+            agreement.setPlant(plant);
+            agreement.setName("Test agreement " + UUID.randomUUID());
+            agreement.setStatus(SharingAgreementStatus.PUBLISHED);
+            agreement.setCreatedAt(Instant.now());
+            agreement.setCreatedBy(null);
+            sharingAgreementRepository.save(agreement);
+        }
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/RegisterPartitionCoefficientsWithFileControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/RegisterPartitionCoefficientsWithFileControllerTest.java
@@ -9,7 +9,15 @@ import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyService;
 import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
 import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
 import org.lucoenergia.conluz.domain.shared.UserPersonalId;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementStatus;
 import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -19,6 +27,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.Files;
+import java.time.Instant;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
@@ -46,6 +56,12 @@ class RegisterPartitionCoefficientsWithFileControllerTest extends BaseController
     private CreateSupplyService createSupplyService;
     @Autowired
     private GetCommunityRepository getCommunityRepository;
+    @Autowired
+    private SupplyRepository supplyJpaRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
 
     @Test
     void importsCoefficientsSuccessfully() throws Exception {
@@ -211,7 +227,37 @@ class RegisterPartitionCoefficientsWithFileControllerTest extends BaseController
         createUserRepository.create(user);
         Supply supply = SupplyMother.random(user).withCode(code).build();
         Community community = getCommunityRepository.findAll().stream().findFirst().get();
-        return createSupplyService.create(supply, UserPersonalId.of(user.getPersonalId()), community.getId());
+        Supply created = createSupplyService.create(supply, UserPersonalId.of(user.getPersonalId()), community.getId());
+        ensurePlantAndPublishedAgreement(created, community.getId());
+        return created;
+    }
+
+    /**
+     * The bulk import path resolves plant/agreement from each supply's community (interim
+     * phase-2d inference), so the community needs a plant with a PUBLISHED agreement. Idempotent
+     * per community: createSupplyWithCode is called multiple times per test, and a second plant for
+     * the same community would violate the one-plant-per-community invariant the resolution relies on.
+     */
+    private void ensurePlantAndPublishedAgreement(Supply supply, UUID communityId) {
+        PlantEntity plant = plantRepository.findBySupplyCommunityId(communityId)
+                .orElseGet(() -> {
+                    SupplyEntity supplyEntity = supplyJpaRepository.getReferenceById(supply.getId());
+                    return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supplyEntity).build());
+                });
+
+        boolean hasPublishedAgreement = sharingAgreementRepository
+                .findFirstByPlantIdAndStatusOrderByCreatedAtDesc(plant.getId(), SharingAgreementStatus.PUBLISHED)
+                .isPresent();
+        if (!hasPublishedAgreement) {
+            SharingAgreementEntity agreement = new SharingAgreementEntity();
+            agreement.setId(UUID.randomUUID());
+            agreement.setPlant(plant);
+            agreement.setName("Test agreement " + UUID.randomUUID());
+            agreement.setStatus(SharingAgreementStatus.PUBLISHED);
+            agreement.setCreatedAt(Instant.now());
+            agreement.setCreatedBy(null);
+            sharingAgreementRepository.save(agreement);
+        }
     }
 
     private MockMultipartFile loadFixture(String classPathLocation, String contentType) throws Exception {

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabaseTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficientRepository;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
 import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
@@ -11,6 +12,11 @@ import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoeffic
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
 import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
 import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementStatus;
 import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +48,12 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Autowired
     private CommunityJpaRepository communityJpaRepository;
 
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+
     private SupplyEntity persistSupply() {
         UserEntity user = UserMother.randomUserEntity();
         userRepository.save(user);
@@ -51,11 +63,25 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
         ));
     }
 
-    private SupplyPartitionCoefficient persist(UUID supplyId, BigDecimal coefficient,
-                                               Instant validFrom, Instant validTo) {
+    private SharingAgreementEntity persistPlantAndPublishedAgreement(SupplyEntity supply) {
+        PlantEntity plant = plantRepository.save(PlantMother.randomPlantEntity().withSupply(supply).build());
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plant);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(SharingAgreementStatus.PUBLISHED);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    private SupplyPartitionCoefficient persist(UUID supplyId, UUID plantId, UUID sharingAgreementId,
+                                               BigDecimal coefficient, Instant validFrom, Instant validTo) {
         return repository.save(new SupplyPartitionCoefficient.Builder()
                 .withId(UUID.randomUUID())
                 .withSupplyId(supplyId)
+                .withPlantId(plantId)
+                .withSharingAgreementId(sharingAgreementId)
                 .withCoefficient(coefficient)
                 .withValidFrom(validFrom)
                 .withValidTo(validTo)
@@ -66,10 +92,11 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void findActiveBySupplyIdReturnsRowWithNullValidTo() {
         SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
-        persist(supply.getId(), BigDecimal.valueOf(1.000000), t0, t1);
-        persist(supply.getId(), BigDecimal.valueOf(2.000000), t1, null);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(1.000000), t0, t1);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(2.000000), t1, null);
 
         Optional<SupplyPartitionCoefficient> result = repository.findActiveBySupplyId(supply.getId());
 
@@ -81,9 +108,12 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void findBySupplyIdAtTimestampRespectsInclusiveLowerBound() {
         SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
         Instant changeAt = Instant.parse("2025-03-01T00:00:00Z");
-        persist(supply.getId(), BigDecimal.valueOf(3.000000), Instant.parse("2024-01-01T00:00:00Z"), changeAt);
-        persist(supply.getId(), BigDecimal.valueOf(4.000000), changeAt, null);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(),
+                BigDecimal.valueOf(3.000000), Instant.parse("2024-01-01T00:00:00Z"), changeAt);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(),
+                BigDecimal.valueOf(4.000000), changeAt, null);
 
         // Query at the exact change time should return the new period (valid_from inclusive)
         Optional<SupplyPartitionCoefficient> result = repository.findBySupplyIdAtTimestamp(supply.getId(), changeAt);
@@ -95,11 +125,12 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void findBySupplyIdInRangeReturnsOverlappingPeriods() {
         SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
         Instant t2 = Instant.parse("2025-06-01T00:00:00Z");
-        persist(supply.getId(), BigDecimal.valueOf(1.000000), t0, t1);
-        persist(supply.getId(), BigDecimal.valueOf(2.000000), t1, null);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(1.000000), t0, t1);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(2.000000), t1, null);
 
         List<SupplyPartitionCoefficient> result = repository.findBySupplyIdInRange(
                 supply.getId(), Instant.parse("2024-06-01T00:00:00Z"), t2);
@@ -110,11 +141,12 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void closeActivePeriodSetsValidToOnOpenRow() {
         SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
         Instant start = Instant.parse("2024-01-01T00:00:00Z");
-        persist(supply.getId(), BigDecimal.valueOf(5.000000), start, null);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(5.000000), start, null);
 
         Instant closeAt = Instant.parse("2025-01-01T00:00:00Z");
-        repository.closeActivePeriod(supply.getId(), closeAt);
+        repository.closeActivePeriod(supply.getId(), agreement.getPlant().getId(), closeAt);
 
         Optional<SupplyPartitionCoefficient> active = repository.findActiveBySupplyId(supply.getId());
         assertFalse(active.isPresent());
@@ -127,13 +159,14 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void uniqueActiveConstraintPreventsSecondOpenRowForSameSupply() {
         SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
-        persist(supply.getId(), BigDecimal.valueOf(3.000000), t0, null);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(3.000000), t0, null);
 
-        // Attempting to persist a second open-ended row for the same supply must fail
+        // Attempting to persist a second open-ended row for the same (plant, supply) must fail
         assertThrows(Exception.class, () -> {
-            persist(supply.getId(), BigDecimal.valueOf(4.000000), t1, null);
+            persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(4.000000), t1, null);
             // Force the flush so the DB constraint fires within this transaction
             jpaRepository.flush();
         });
@@ -142,16 +175,20 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void findAllActiveAtTimestampReturnsOnlyActiveRows() {
         SupplyEntity supply1 = persistSupply();
+        SharingAgreementEntity agreement1 = persistPlantAndPublishedAgreement(supply1);
         SupplyEntity supply2 = persistSupply();
+        SharingAgreementEntity agreement2 = persistPlantAndPublishedAgreement(supply2);
+        SupplyEntity supply3 = persistSupply();
+        SharingAgreementEntity agreement3 = persistPlantAndPublishedAgreement(supply3);
 
         Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
         Instant queryAt = Instant.parse("2025-06-01T00:00:00Z");
 
-        persist(supply1.getId(), BigDecimal.valueOf(10.0), t0, null);
-        persist(supply2.getId(), BigDecimal.valueOf(20.0), t0, null);
+        persist(supply1.getId(), agreement1.getPlant().getId(), agreement1.getId(), BigDecimal.valueOf(10.0), t0, null);
+        persist(supply2.getId(), agreement2.getPlant().getId(), agreement2.getId(), BigDecimal.valueOf(20.0), t0, null);
         // closed row — should not appear
-        persist(persistSupply().getId(), BigDecimal.valueOf(30.0), t0, t1);
+        persist(supply3.getId(), agreement3.getPlant().getId(), agreement3.getId(), BigDecimal.valueOf(30.0), t0, t1);
 
         List<SupplyPartitionCoefficient> result = repository.findAllActiveAtTimestamp(queryAt);
 
@@ -163,12 +200,13 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
     @Test
     void findAllBySupplyIdOrderByValidFromAscReturnsChronologicalHistory() {
         SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
         Instant t0 = Instant.parse("2023-01-01T00:00:00Z");
         Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
         Instant t2 = Instant.parse("2025-01-01T00:00:00Z");
-        persist(supply.getId(), BigDecimal.valueOf(1.000000), t0, t1);
-        persist(supply.getId(), BigDecimal.valueOf(2.000000), t1, t2);
-        persist(supply.getId(), BigDecimal.valueOf(3.000000), t2, null);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(1.000000), t0, t1);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(2.000000), t1, t2);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(3.000000), t2, null);
 
         List<SupplyPartitionCoefficient> history = repository.findAllBySupplyIdOrderByValidFromAsc(supply.getId());
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabaseTest.java
@@ -19,6 +19,7 @@ import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementRe
 import org.lucoenergia.conluz.infrastructure.production.plant.SharingAgreementStatus;
 import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -53,6 +54,9 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
 
     @Autowired
     private SharingAgreementRepository sharingAgreementRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     private SupplyEntity persistSupply() {
         UserEntity user = UserMother.randomUserEntity();
@@ -214,5 +218,68 @@ class SupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegrationTe
         assertEquals(t0, history.get(0).getValidFrom());
         assertEquals(t1, history.get(1).getValidFrom());
         assertEquals(t2, history.get(2).getValidFrom());
+    }
+
+    // --- Commit 2: exclusion constraint coverage ---
+
+    @Test
+    void crossPlantOverlapIsAllowedForSameSupply() {
+        SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement1 = persistPlantAndPublishedAgreement(supply);
+        SharingAgreementEntity agreement2 = persistPlantAndPublishedAgreement(supply);
+        Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
+        Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
+
+        // Same supply, same [t0, t1) window, but two different plants -- must be allowed.
+        persist(supply.getId(), agreement1.getPlant().getId(), agreement1.getId(), BigDecimal.valueOf(0.4), t0, t1);
+        persist(supply.getId(), agreement2.getPlant().getId(), agreement2.getId(), BigDecimal.valueOf(0.6), t0, t1);
+
+        assertDoesNotThrow(() -> jpaRepository.flush());
+    }
+
+    @Test
+    void sameSupplyAndPlantBoundedOverlapIsRejectedByExclusionConstraint() {
+        SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
+        Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
+        Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
+        Instant t2 = Instant.parse("2024-06-01T00:00:00Z");
+        Instant t3 = Instant.parse("2025-06-01T00:00:00Z");
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(1.0), t0, t1);
+
+        // [t2, t3) overlaps [t0, t1) even though neither row is open-ended.
+        assertThrows(Exception.class, () -> {
+            persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(2.0), t2, t3);
+            jpaRepository.flush();
+        });
+    }
+
+    @Test
+    void adjacentBoundaryPeriodsAreAcceptedByExclusionConstraint() {
+        SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
+        Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
+        Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
+        Instant t2 = Instant.parse("2026-01-01T00:00:00Z");
+
+        // [t0, t1) then [t1, t2) share a boundary instant -- '[)' must treat them as adjacent, not overlapping.
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(1.0), t0, t1);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(2.0), t1, t2);
+
+        assertDoesNotThrow(() -> jpaRepository.flush());
+    }
+
+    @Test
+    void exclusionConstraintPartialPredicatePinsValidFromIsNotNull() {
+        // valid_from is still NOT NULL on every row in this phase, so the WHERE (valid_from IS NOT
+        // NULL) predicate is currently a no-op -- it exists to future-proof the constraint against an
+        // anticipated later relaxation of valid_from's nullability. This test pins the predicate's
+        // presence so that future change doesn't silently drop it.
+        String constraintDef = jdbcTemplate.queryForObject(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'no_overlapping_coefficients'",
+                String.class);
+
+        assertNotNull(constraintDef);
+        assertTrue(constraintDef.contains("valid_from IS NOT NULL"), "unexpected constraint definition: " + constraintDef);
     }
 }


### PR DESCRIPTION
# [conluz-208] Link partition coefficients to plant and sharing agreement`

## Summary

- `supply_partition_coefficient` could only express *which supply* a coefficient belongs to, not *which plant* or *which agreement* authored it. Once a supply can participate in more than one plant, "one active row per supply" is the wrong invariant — two simultaneous active rows become legitimate as long as they're in different plants.
- Adds `plant_id` and `sharing_agreement_id` to `supply_partition_coefficient` via a 7-changeset Liquibase migration: enable `btree_gist` → add nullable columns (guarded by a precondition asserting every community that owns coefficients has exactly one plant) → backfill one synthetic `PUBLISHED` `sharing_agreement` per plant → backfill both columns → make both `NOT NULL` → drop the old partial unique index → add a GiST exclusion constraint scoped to `(plant_id, supply_id)` with half-open `[)` range semantics.
- Every changeset has a real, executed rollback (this is the only phase-2 migration touching production data).
- Until phase 3 teaches the distributor-file importer to create real agreements, `PartitionCoefficientServiceImpl.registerCoefficientChange` infers `plant_id`/`sharing_agreement_id` from the supply's community as an explicitly-marked interim measure, so both write paths (single-supply endpoint, bulk TXT import) keep working.
- Added a minimal read-only `SharingAgreement` slice (domain interface + `*RepositoryDatabase`, no JPA leaking into `@Service` code) — just enough to resolve "current PUBLISHED agreement for a plant"; the full CRUD surface remains phase 5.

## Commits

1. **`feat: link partition coefficients to plant and sharing agreement`** — migration, entity/domain/repository changes, interim resolution, and the test fixes required to keep the existing suite compiling and passing.
2. **`test: coefficient overlap exclusion constraint`** — new integration tests: cross-plant overlap allowed, same-plant overlap rejected (open-ended and bounded), adjacent boundary accepted, and the partial predicate on `valid_from` pinned via `pg_get_constraintdef`.

## Verification

- `./gradlew test`: 1119 tests, 0 failures, including `JpaUsageArchTest` and the rest of the ArchUnit suite.
- Rollback round-trip verified against a throwaway Postgres container via the Liquibase Docker CLI, both as a batch (`rollback-count 7` → `update`) and changeset-by-changeset — schema and `btree_gist` extension state match exactly before/after.
- Precondition-HALT proven: seeded a community with 2 plants and an existing coefficient row, confirmed Liquibase halts with `Expected '0' got '1'` naming `add_plant_and_sharing_agreement_to_supply_partition_coefficient`, and confirmed no partial DDL was left behind.

## Outstanding before this ships

⚠️ **Someone with real production DB access must run this diagnostic and confirm it returns `0`** before the exclusion-constraint changeset (`add_supply_partition_coefficient_no_overlapping_exclusion_constraint`) is deployed — the new constraint is strictly stronger than the old index (it also forbids overlapping *bounded* ranges, not just a second open-ended row):
```sql
SELECT count(*)
FROM supply_partition_coefficient a
JOIN supply_partition_coefficient b
  ON a.supply_id = b.supply_id AND a.id < b.id
 AND a.valid_from IS NOT NULL AND b.valid_from IS NOT NULL
 AND tstzrange(a.valid_from, a.valid_to, '[)') && tstzrange(b.valid_from, b.valid_to, '[)');
```
The changeset also embeds a precise version of this same check as its own HALT precondition, so a non-zero count will halt the migration cleanly rather than fail mid-`ALTER TABLE` — but running it ahead of time avoids a failed deploy.

## Do not (out of scope, confirmed with reviewer)

- Production/β calculation (InfluxQL) — phase 4.
- Distributor file parsing — phase 3.
- REST API for sharing agreements — phase 5.
- Σβ = 1 enforcement or coefficient normalization.