### PR TITLE
[conluz-218] Add sharing-agreement lifecycle write API (create/patch/delete/publish)

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/admin/community/access/PlantAccessGuard.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/community/access/PlantAccessGuard.java
@@ -21,4 +21,16 @@ public interface PlantAccessGuard {
      * given plant. Allowed for any enabled member (regardless of role) of the plant's community.
      */
     boolean canReadSharingAgreement(UUID plantId, UUID sharingAgreementId);
+
+    /**
+     * Whether the current user may create a sharing agreement under the given plant. Only
+     * community admins of the plant's community.
+     */
+    boolean canManageSharingAgreement(UUID plantId);
+
+    /**
+     * Whether the current user may patch, delete or publish the given sharing agreement, which
+     * must belong to the given plant. Only community admins of the plant's community.
+     */
+    boolean canManageSharingAgreement(UUID plantId, UUID sharingAgreementId);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepository.java
@@ -37,4 +37,11 @@ public interface SupplyPartitionCoefficientRepository {
     void closeActivePeriod(UUID supplyId, UUID plantId, Instant validTo);
 
     void syncSupplyPartitionCoefficient(UUID supplyId, BigDecimal newCoefficient);
+
+    /**
+     * Read-only existence check used by the sharing-agreement publish precondition. Phase 5c's
+     * coefficient-materialization work should extend this repository rather than adding a
+     * parallel one.
+     */
+    boolean existsBySharingAgreementId(UUID sharingAgreementId);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/create/CreateSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/create/CreateSharingAgreementRepository.java
@@ -1,0 +1,8 @@
+package org.lucoenergia.conluz.domain.production.plant.create;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+
+public interface CreateSharingAgreementRepository {
+
+    SharingAgreement create(SharingAgreement agreement);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/create/CreateSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/create/CreateSharingAgreementService.java
@@ -1,0 +1,16 @@
+package org.lucoenergia.conluz.domain.production.plant.create;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+
+import java.util.UUID;
+
+public interface CreateSharingAgreementService {
+
+    /**
+     * Creates a new DRAFT sharing agreement under the given plant. {@code installedPowerKw} is
+     * snapshotted from the plant's current {@code totalPower} at creation time, not a live join.
+     *
+     * @param createdBy the acting user's id; never null on this path
+     */
+    SharingAgreement create(UUID plantId, String name, String notes, UUID createdBy);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/delete/DeleteSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/delete/DeleteSharingAgreementRepository.java
@@ -1,0 +1,8 @@
+package org.lucoenergia.conluz.domain.production.plant.delete;
+
+import java.util.UUID;
+
+public interface DeleteSharingAgreementRepository {
+
+    void delete(UUID plantId, UUID sharingAgreementId);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/delete/DeleteSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/delete/DeleteSharingAgreementService.java
@@ -1,0 +1,13 @@
+package org.lucoenergia.conluz.domain.production.plant.delete;
+
+import java.util.UUID;
+
+public interface DeleteSharingAgreementService {
+
+    /**
+     * @throws org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException
+     *         if the agreement is not DRAFT -- deleting a PUBLISHED agreement would destroy the
+     *         historical basis of past billing.
+     */
+    void delete(UUID plantId, UUID sharingAgreementId);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/publish/PublishSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/publish/PublishSharingAgreementRepository.java
@@ -1,0 +1,10 @@
+package org.lucoenergia.conluz.domain.production.plant.publish;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+
+import java.util.UUID;
+
+public interface PublishSharingAgreementRepository {
+
+    SharingAgreement publish(UUID plantId, UUID sharingAgreementId);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/publish/PublishSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/publish/PublishSharingAgreementService.java
@@ -1,0 +1,18 @@
+package org.lucoenergia.conluz.domain.production.plant.publish;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+
+import java.util.UUID;
+
+public interface PublishSharingAgreementService {
+
+    /**
+     * Transitions a sharing agreement from DRAFT to PUBLISHED.
+     *
+     * @throws org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException
+     *         if the agreement is not DRAFT
+     * @throws org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementHasNoCoefficientsException
+     *         if the agreement has no partition coefficients yet
+     */
+    SharingAgreement publish(UUID plantId, UUID sharingAgreementId);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreement.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreement.java
@@ -63,6 +63,17 @@ public class SharingAgreement {
         return createdBy;
     }
 
+    /**
+     * Throws {@link SharingAgreementNotDraftException} unless this agreement is still DRAFT. Used
+     * by patch/delete/publish to keep a PUBLISHED agreement's data (including the installed-power
+     * snapshot) an immutable historical record.
+     */
+    public void assertDraft() {
+        if (status != SharingAgreementStatus.DRAFT) {
+            throw new SharingAgreementNotDraftException(id, status);
+        }
+    }
+
     public static class Builder {
         private UUID id;
         private UUID plantId;

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreementHasNoCoefficientsException.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreementHasNoCoefficientsException.java
@@ -1,0 +1,16 @@
+package org.lucoenergia.conluz.domain.production.plant.sharingagreement;
+
+import java.util.UUID;
+
+public class SharingAgreementHasNoCoefficientsException extends RuntimeException {
+
+    private final UUID id;
+
+    public SharingAgreementHasNoCoefficientsException(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreementNotDraftException.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreementNotDraftException.java
@@ -1,0 +1,22 @@
+package org.lucoenergia.conluz.domain.production.plant.sharingagreement;
+
+import java.util.UUID;
+
+public class SharingAgreementNotDraftException extends RuntimeException {
+
+    private final UUID id;
+    private final SharingAgreementStatus currentStatus;
+
+    public SharingAgreementNotDraftException(UUID id, SharingAgreementStatus currentStatus) {
+        this.id = id;
+        this.currentStatus = currentStatus;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public SharingAgreementStatus getCurrentStatus() {
+        return currentStatus;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreement.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreement.java
@@ -1,0 +1,58 @@
+package org.lucoenergia.conluz.domain.production.plant.update;
+
+import java.math.BigDecimal;
+
+/**
+ * The updatable fields of a sharing agreement. Bundling them here, rather than passing them as
+ * individual parameters to {@link UpdateSharingAgreementService}/{@link UpdateSharingAgreementRepository},
+ * means adding or removing an updatable field never changes those method signatures.
+ */
+public class UpdateSharingAgreement {
+
+    private final String name;
+    private final String notes;
+    private final BigDecimal installedPowerKw;
+
+    private UpdateSharingAgreement(Builder builder) {
+        this.name = builder.name;
+        this.notes = builder.notes;
+        this.installedPowerKw = builder.installedPowerKw;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public BigDecimal getInstalledPowerKw() {
+        return installedPowerKw;
+    }
+
+    public static class Builder {
+        private String name;
+        private String notes;
+        private BigDecimal installedPowerKw;
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withNotes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public Builder withInstalledPowerKw(BigDecimal installedPowerKw) {
+            this.installedPowerKw = installedPowerKw;
+            return this;
+        }
+
+        public UpdateSharingAgreement build() {
+            return new UpdateSharingAgreement(this);
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementRepository.java
@@ -1,0 +1,11 @@
+package org.lucoenergia.conluz.domain.production.plant.update;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface UpdateSharingAgreementRepository {
+
+    SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes, BigDecimal installedPowerKw);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementRepository.java
@@ -2,10 +2,9 @@ package org.lucoenergia.conluz.domain.production.plant.update;
 
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface UpdateSharingAgreementRepository {
 
-    SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes, BigDecimal installedPowerKw);
+    SharingAgreement update(UUID plantId, UUID sharingAgreementId, UpdateSharingAgreement update);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementService.java
@@ -2,17 +2,16 @@ package org.lucoenergia.conluz.domain.production.plant.update;
 
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface UpdateSharingAgreementService {
 
     /**
-     * Updates the descriptive fields of a DRAFT sharing agreement. Never touches {@code status},
+     * Replaces the descriptive fields of a DRAFT sharing agreement. Never touches {@code status},
      * {@code plantId}, {@code createdAt} or {@code createdBy}.
      *
      * @throws org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException
      *         if the agreement is not DRAFT
      */
-    SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes, BigDecimal installedPowerKw);
+    SharingAgreement update(UUID plantId, UUID sharingAgreementId, UpdateSharingAgreement update);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/plant/update/UpdateSharingAgreementService.java
@@ -1,0 +1,18 @@
+package org.lucoenergia.conluz.domain.production.plant.update;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface UpdateSharingAgreementService {
+
+    /**
+     * Updates the descriptive fields of a DRAFT sharing agreement. Never touches {@code status},
+     * {@code plantId}, {@code createdAt} or {@code createdBy}.
+     *
+     * @throws org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException
+     *         if the agreement is not DRAFT
+     */
+    SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes, BigDecimal installedPowerKw);
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/access/CommunityAccessGuardImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/access/CommunityAccessGuardImpl.java
@@ -134,6 +134,16 @@ public class CommunityAccessGuardImpl implements CommunityAccessGuard {
     }
 
     @Override
+    public boolean canManageSharingAgreement(UUID plantId) {
+        return plantAccessGuard.canManageSharingAgreement(plantId);
+    }
+
+    @Override
+    public boolean canManageSharingAgreement(UUID plantId, UUID sharingAgreementId) {
+        return plantAccessGuard.canManageSharingAgreement(plantId, sharingAgreementId);
+    }
+
+    @Override
     public Set<UUID> visibleCommunityIds() {
         User user = helper.getCurrentUser().orElse(null);
         return helper.visibleCommunityIds(user);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/access/PlantAccessGuardImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/access/PlantAccessGuardImpl.java
@@ -106,6 +106,31 @@ class PlantAccessGuardImpl implements PlantAccessGuard {
         return true;
     }
 
+    @Override
+    public boolean canManageSharingAgreement(UUID plantId) {
+        // Same precondition as managing the plant itself; kept as a separate method so the
+        // @PreAuthorize SpEL at the sharing-agreement endpoints reads correctly and the two rules
+        // can diverge later without touching call sites.
+        return canManagePlant(plantId);
+    }
+
+    @Override
+    public boolean canManageSharingAgreement(UUID plantId, UUID sharingAgreementId) {
+        User user = helper.getCurrentUser().orElse(null);
+        if (user == null) {
+            return false;
+        }
+        UUID communityId = getCommunityIdOfVisiblePlant(user, plantId);
+        // The agreement is the resource whose existence must not leak, same as canReadSharingAgreement.
+        SharingAgreement agreement = getSharingAgreementRepository.findById(sharingAgreementId).orElse(null);
+        if (agreement == null || !plantId.equals(agreement.getPlantId())) {
+            throw new SharingAgreementNotFoundException(sharingAgreementId);
+        }
+        // A member of the plant's community can see the agreement but only community admins may
+        // manage it (member-non-admin -> 403).
+        return helper.hasCommunityAdminRoleIn(user, communityId);
+    }
+
     /**
      * Resolves the community of the plant the user is allowed to see, throwing
      * {@link PlantNotFoundException} (404) when the plant does not exist or the user is not a

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientJpaRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientJpaRepository.java
@@ -64,4 +64,11 @@ public interface SupplyPartitionCoefficientJpaRepository extends JpaRepository<S
     @Query("UPDATE SupplyPartitionCoefficientEntity e SET e.validTo = :validTo " +
             "WHERE e.supply.id = :supplyId AND e.plant.id = :plantId AND e.validTo IS NULL")
     void closeActivePeriod(@Param("supplyId") UUID supplyId, @Param("plantId") UUID plantId, @Param("validTo") Instant validTo);
+
+    /**
+     * Read-only existence check used by the sharing-agreement publish precondition. Phase 5c's
+     * coefficient-materialization work should extend this repository rather than adding a
+     * parallel one.
+     */
+    boolean existsBySharingAgreementId(UUID sharingAgreementId);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/SupplyPartitionCoefficientRepositoryDatabase.java
@@ -135,4 +135,10 @@ public class SupplyPartitionCoefficientRepositoryDatabase implements SupplyParti
         supply.setPartitionCoefficient(newCoefficient.floatValue());
         supplyRepository.save(supply);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsBySharingAgreementId(UUID sharingAgreementId) {
+        return jpaRepository.existsBySharingAgreementId(sharingAgreementId);
+    }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantExceptionHandler.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/PlantExceptionHandler.java
@@ -2,10 +2,13 @@ package org.lucoenergia.conluz.infrastructure.production.plant;
 
 import org.lucoenergia.conluz.domain.production.plant.PlantAlreadyExistsException;
 import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementHasNoCoefficientsException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreementfile.SharingAgreementFileNotFoundException;
 import org.lucoenergia.conluz.infrastructure.shared.error.ErrorBuilder;
 import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestErrorCode;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
@@ -72,5 +75,27 @@ public class PlantExceptionHandler {
                 LocaleContextHolder.getLocale()
         );
         return errorBuilder.build(message, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(SharingAgreementNotDraftException.class)
+    public ResponseEntity<RestError> handleException(SharingAgreementNotDraftException e) {
+
+        String message = messageSource.getMessage(
+                "error.sharing.agreement.not.draft",
+                new Object[]{e.getId(), e.getCurrentStatus()},
+                LocaleContextHolder.getLocale()
+        );
+        return errorBuilder.build(message, RestErrorCode.SHARING_AGREEMENT_NOT_DRAFT, null, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(SharingAgreementHasNoCoefficientsException.class)
+    public ResponseEntity<RestError> handleException(SharingAgreementHasNoCoefficientsException e) {
+
+        String message = messageSource.getMessage(
+                "error.sharing.agreement.no.coefficients",
+                Collections.singletonList(e.getId()).toArray(),
+                LocaleContextHolder.getLocale()
+        );
+        return errorBuilder.build(message, RestErrorCode.SHARING_AGREEMENT_HAS_NO_COEFFICIENTS, null, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementBody.java
@@ -1,0 +1,30 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(requiredProperties = {"name"})
+public class CreateSharingAgreementBody {
+
+    @Schema(description = "Human-readable label for the agreement", example = "2024 winter distribution")
+    @NotBlank
+    private String name;
+    @Schema(description = "Free-text notes about the agreement", example = "Adjusted after member B joined")
+    private String notes;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementController.java
@@ -1,0 +1,86 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.auth.AuthService;
+import org.lucoenergia.conluz.domain.production.plant.create.CreateSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping(
+        value = "/api/v1/plants/{plantId}/sharing-agreements",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+)
+@Validated
+public class CreateSharingAgreementController {
+
+    private final CreateSharingAgreementService service;
+    private final AuthService authService;
+
+    public CreateSharingAgreementController(CreateSharingAgreementService service, AuthService authService) {
+        this.service = service;
+        this.authService = authService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Creates a new sharing agreement under a plant",
+            description = """
+                    This endpoint creates a new DRAFT sharing agreement under the given plant. The
+                    agreement's installed power is snapshotted from the plant's current total power at
+                    creation time.
+
+                    **Required: Community Admin**
+
+                    Returns 404 if the plant does not exist or the caller is not a member of its
+                    community, to avoid leaking the plant's existence.
+
+                    Authentication is required using a Bearer token.
+                    """,
+            tags = ApiTag.SHARING_AGREEMENTS,
+            operationId = "createSharingAgreement",
+            security = @SecurityRequirement(name = "bearerToken")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "The sharing agreement has been successfully created.",
+                    useReturnTypeSchema = true
+            )
+    })
+    @BadRequestErrorResponse
+    @UnauthorizedErrorResponse
+    @ForbiddenErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId)")
+    public SharingAgreementResponse createSharingAgreement(@PathVariable UUID plantId,
+                                                            @Valid @RequestBody CreateSharingAgreementBody body) {
+        User currentUser = authService.getCurrentUser()
+                .orElseThrow(() -> new IllegalStateException("No authenticated user for an authorized request"));
+        SharingAgreement agreement = service.create(plantId, body.getName(), body.getNotes(), currentUser.getId());
+        return new SharingAgreementResponse(agreement);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementRepositoryDatabase.java
@@ -1,0 +1,48 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.create.CreateSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.shared.PlantId;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntityMapper;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Repository
+public class CreateSharingAgreementRepositoryDatabase implements CreateSharingAgreementRepository {
+
+    private final SharingAgreementRepository sharingAgreementRepository;
+    private final PlantRepository plantRepository;
+    private final SharingAgreementEntityMapper mapper;
+
+    public CreateSharingAgreementRepositoryDatabase(SharingAgreementRepository sharingAgreementRepository,
+                                                     PlantRepository plantRepository,
+                                                     SharingAgreementEntityMapper mapper) {
+        this.sharingAgreementRepository = sharingAgreementRepository;
+        this.plantRepository = plantRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public SharingAgreement create(SharingAgreement agreement) {
+        PlantEntity plantEntity = plantRepository.findById(agreement.getPlantId())
+                .orElseThrow(() -> new PlantNotFoundException(PlantId.of(agreement.getPlantId())));
+
+        SharingAgreementEntity entity = new SharingAgreementEntity();
+        entity.setId(agreement.getId());
+        entity.setPlant(plantEntity);
+        entity.setName(agreement.getName());
+        entity.setNotes(agreement.getNotes());
+        entity.setStatus(agreement.getStatus());
+        entity.setInstalledPowerKw(agreement.getInstalledPowerKw());
+        entity.setCreatedAt(agreement.getCreatedAt());
+        entity.setCreatedBy(agreement.getCreatedBy());
+
+        return mapper.map(sharingAgreementRepository.save(entity));
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementServiceImpl.java
@@ -1,0 +1,49 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.create.CreateSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.create.CreateSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.get.GetPlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.shared.PlantId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Transactional
+@Service
+public class CreateSharingAgreementServiceImpl implements CreateSharingAgreementService {
+
+    private final GetPlantRepository getPlantRepository;
+    private final CreateSharingAgreementRepository repository;
+
+    public CreateSharingAgreementServiceImpl(GetPlantRepository getPlantRepository,
+                                              CreateSharingAgreementRepository repository) {
+        this.getPlantRepository = getPlantRepository;
+        this.repository = repository;
+    }
+
+    @Override
+    public SharingAgreement create(UUID plantId, String name, String notes, UUID createdBy) {
+        Plant plant = getPlantRepository.findById(PlantId.of(plantId))
+                .orElseThrow(() -> new PlantNotFoundException(PlantId.of(plantId)));
+
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(UUID.randomUUID())
+                .withPlantId(plantId)
+                .withName(name)
+                .withNotes(notes)
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .withInstalledPowerKw(BigDecimal.valueOf(plant.getTotalPower()))
+                .withCreatedAt(Instant.now())
+                .withCreatedBy(createdBy)
+                .build();
+
+        return repository.create(agreement);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementController.java
@@ -1,0 +1,90 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.delete;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.lucoenergia.conluz.domain.production.plant.delete.DeleteSharingAgreementService;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+public class DeleteSharingAgreementController {
+
+    private final DeleteSharingAgreementService service;
+
+    public DeleteSharingAgreementController(DeleteSharingAgreementService service) {
+        this.service = service;
+    }
+
+    @DeleteMapping
+    @Operation(
+            summary = "Removes a DRAFT sharing agreement",
+            description = """
+                    This endpoint removes a sharing agreement. Only DRAFT agreements can be deleted:
+                    deleting a PUBLISHED agreement would destroy the historical basis of past billing.
+
+                    **Required: Community Admin**
+
+                    Returns 404 if the plant or the agreement does not exist, does not belong to this
+                    plant, or the caller is not a member of its community, to avoid leaking existence.
+                    Returns 409 if the agreement is not in DRAFT status.
+
+                    Authentication is required using a Bearer token.
+                    """,
+            tags = ApiTag.SHARING_AGREEMENTS,
+            operationId = "deleteSharingAgreement",
+            security = @SecurityRequirement(name = "bearerToken")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Sharing agreement deleted successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "The agreement is not in DRAFT status.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RestError.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                               "timestamp": "2024-01-03T10:10:25.534035352+01:00",
+                                               "status": 409,
+                                               "message": "Sharing agreement 'ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c' is not in DRAFT status.",
+                                               "traceId": "6e602860-80f7-4802-b20f-8b53fb011013",
+                                               "errors": []
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @ForbiddenErrorResponse
+    @UnauthorizedErrorResponse
+    @BadRequestErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    public void deleteSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id) {
+        service.delete(plantId, id);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementRepositoryDatabase.java
@@ -1,0 +1,31 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.delete;
+
+import org.lucoenergia.conluz.domain.production.plant.delete.DeleteSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Transactional
+@Repository
+public class DeleteSharingAgreementRepositoryDatabase implements DeleteSharingAgreementRepository {
+
+    private final SharingAgreementRepository sharingAgreementRepository;
+
+    public DeleteSharingAgreementRepositoryDatabase(SharingAgreementRepository sharingAgreementRepository) {
+        this.sharingAgreementRepository = sharingAgreementRepository;
+    }
+
+    @Override
+    public void delete(UUID plantId, UUID sharingAgreementId) {
+        SharingAgreementEntity entity = sharingAgreementRepository.findById(sharingAgreementId)
+                .orElseThrow(() -> new SharingAgreementNotFoundException(sharingAgreementId));
+        if (!plantId.equals(entity.getPlant().getId())) {
+            throw new SharingAgreementNotFoundException(sharingAgreementId);
+        }
+        sharingAgreementRepository.delete(entity);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementServiceImpl.java
@@ -1,0 +1,31 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.delete;
+
+import org.lucoenergia.conluz.domain.production.plant.delete.DeleteSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.delete.DeleteSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Transactional
+@Service
+public class DeleteSharingAgreementServiceImpl implements DeleteSharingAgreementService {
+
+    private final GetSharingAgreementService getSharingAgreementService;
+    private final DeleteSharingAgreementRepository repository;
+
+    public DeleteSharingAgreementServiceImpl(GetSharingAgreementService getSharingAgreementService,
+                                              DeleteSharingAgreementRepository repository) {
+        this.getSharingAgreementService = getSharingAgreementService;
+        this.repository = repository;
+    }
+
+    @Override
+    public void delete(UUID plantId, UUID sharingAgreementId) {
+        SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
+        agreement.assertDraft();
+        repository.delete(plantId, sharingAgreementId);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementController.java
@@ -1,0 +1,95 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.publish;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.lucoenergia.conluz.domain.production.plant.publish.PublishSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/publish", produces = MediaType.APPLICATION_JSON_VALUE)
+public class PublishSharingAgreementController {
+
+    private final PublishSharingAgreementService service;
+
+    public PublishSharingAgreementController(PublishSharingAgreementService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Publishes a DRAFT sharing agreement",
+            description = """
+                    This endpoint transitions a sharing agreement from DRAFT to PUBLISHED. The
+                    agreement must already have at least one partition coefficient.
+
+                    **Required: Community Admin**
+
+                    Returns 404 if the plant or the agreement does not exist, does not belong to this
+                    plant, or the caller is not a member of its community, to avoid leaking existence.
+                    Returns 409 if the agreement is not in DRAFT status, or if it has no partition
+                    coefficients yet.
+
+                    Authentication is required using a Bearer token.
+                    """,
+            tags = ApiTag.SHARING_AGREEMENTS,
+            operationId = "publishSharingAgreement",
+            security = @SecurityRequirement(name = "bearerToken")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "The sharing agreement has been successfully published.",
+                    useReturnTypeSchema = true
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "The agreement is not in DRAFT status, or it has no partition coefficients yet.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RestError.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                               "timestamp": "2024-01-03T10:10:25.534035352+01:00",
+                                               "status": 409,
+                                               "message": "Sharing agreement 'ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c' cannot be published because it has no partition coefficients.",
+                                               "traceId": "6e602860-80f7-4802-b20f-8b53fb011013",
+                                               "errors": []
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @BadRequestErrorResponse
+    @UnauthorizedErrorResponse
+    @ForbiddenErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    public SharingAgreementResponse publishSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id) {
+        SharingAgreement agreement = service.publish(plantId, id);
+        return new SharingAgreementResponse(agreement);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementRepositoryDatabase.java
@@ -1,0 +1,40 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.publish;
+
+import org.lucoenergia.conluz.domain.production.plant.publish.PublishSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntityMapper;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Transactional
+@Repository
+public class PublishSharingAgreementRepositoryDatabase implements PublishSharingAgreementRepository {
+
+    private final SharingAgreementRepository sharingAgreementRepository;
+    private final SharingAgreementEntityMapper mapper;
+
+    public PublishSharingAgreementRepositoryDatabase(SharingAgreementRepository sharingAgreementRepository,
+                                                      SharingAgreementEntityMapper mapper) {
+        this.sharingAgreementRepository = sharingAgreementRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public SharingAgreement publish(UUID plantId, UUID sharingAgreementId) {
+        SharingAgreementEntity entity = sharingAgreementRepository.findById(sharingAgreementId)
+                .orElseThrow(() -> new SharingAgreementNotFoundException(sharingAgreementId));
+        if (!plantId.equals(entity.getPlant().getId())) {
+            throw new SharingAgreementNotFoundException(sharingAgreementId);
+        }
+
+        entity.setStatus(SharingAgreementStatus.PUBLISHED);
+
+        return mapper.map(sharingAgreementRepository.save(entity));
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementServiceImpl.java
@@ -1,0 +1,39 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.publish;
+
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.publish.PublishSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.publish.PublishSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementHasNoCoefficientsException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Transactional
+@Service
+public class PublishSharingAgreementServiceImpl implements PublishSharingAgreementService {
+
+    private final GetSharingAgreementService getSharingAgreementService;
+    private final SupplyPartitionCoefficientRepository supplyPartitionCoefficientRepository;
+    private final PublishSharingAgreementRepository repository;
+
+    public PublishSharingAgreementServiceImpl(GetSharingAgreementService getSharingAgreementService,
+                                               SupplyPartitionCoefficientRepository supplyPartitionCoefficientRepository,
+                                               PublishSharingAgreementRepository repository) {
+        this.getSharingAgreementService = getSharingAgreementService;
+        this.supplyPartitionCoefficientRepository = supplyPartitionCoefficientRepository;
+        this.repository = repository;
+    }
+
+    @Override
+    public SharingAgreement publish(UUID plantId, UUID sharingAgreementId) {
+        SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
+        agreement.assertDraft();
+        if (!supplyPartitionCoefficientRepository.existsBySharingAgreementId(sharingAgreementId)) {
+            throw new SharingAgreementHasNoCoefficientsException(sharingAgreementId);
+        }
+        return repository.publish(plantId, sharingAgreementId);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementBody.java
@@ -1,0 +1,44 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+@Schema(requiredProperties = {"name", "installedPowerKw"})
+public class UpdateSharingAgreementBody {
+
+    @Schema(description = "Human-readable label for the agreement", example = "2024 winter distribution")
+    @NotBlank
+    private String name;
+    @Schema(description = "Free-text notes about the agreement", example = "Adjusted after member B joined")
+    private String notes;
+    @Schema(description = "Snapshot of the plant's installed power at authoring time, in kW", example = "12.5")
+    @Positive
+    private BigDecimal installedPowerKw;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public BigDecimal getInstalledPowerKw() {
+        return installedPowerKw;
+    }
+
+    public void setInstalledPowerKw(BigDecimal installedPowerKw) {
+        this.installedPowerKw = installedPowerKw;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementBody.java
@@ -2,7 +2,9 @@ package org.lucoenergia.conluz.infrastructure.production.plant.update;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreement;
 
 import java.math.BigDecimal;
 
@@ -15,6 +17,7 @@ public class UpdateSharingAgreementBody {
     @Schema(description = "Free-text notes about the agreement", example = "Adjusted after member B joined")
     private String notes;
     @Schema(description = "Snapshot of the plant's installed power at authoring time, in kW", example = "12.5")
+    @NotNull
     @Positive
     private BigDecimal installedPowerKw;
 
@@ -40,5 +43,13 @@ public class UpdateSharingAgreementBody {
 
     public void setInstalledPowerKw(BigDecimal installedPowerKw) {
         this.installedPowerKw = installedPowerKw;
+    }
+
+    public UpdateSharingAgreement mapToUpdateSharingAgreement() {
+        return new UpdateSharingAgreement.Builder()
+                .withName(name)
+                .withNotes(notes)
+                .withInstalledPowerKw(installedPowerKw)
+                .build();
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementController.java
@@ -1,0 +1,104 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementService;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping(
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+)
+@Validated
+public class UpdateSharingAgreementController {
+
+    private final UpdateSharingAgreementService service;
+
+    public UpdateSharingAgreementController(UpdateSharingAgreementService service) {
+        this.service = service;
+    }
+
+    @PatchMapping
+    @Operation(
+            summary = "Updates a DRAFT sharing agreement's name, notes and installed power",
+            description = """
+                    This endpoint updates the name, notes and installed power of a sharing agreement.
+                    Its status, plant and creation metadata can never be changed through this endpoint.
+
+                    **Required: Community Admin**
+
+                    Returns 404 if the plant or the agreement does not exist, does not belong to this
+                    plant, or the caller is not a member of its community, to avoid leaking existence.
+                    Returns 409 if the agreement is not in DRAFT status.
+
+                    Authentication is required using a Bearer token.
+                    """,
+            tags = ApiTag.SHARING_AGREEMENTS,
+            operationId = "updateSharingAgreement",
+            security = @SecurityRequirement(name = "bearerToken")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "The sharing agreement has been successfully updated.",
+                    useReturnTypeSchema = true
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "The agreement is not in DRAFT status.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RestError.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                               "timestamp": "2024-01-03T10:10:25.534035352+01:00",
+                                               "status": 409,
+                                               "message": "Sharing agreement 'ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c' is not in DRAFT status.",
+                                               "traceId": "6e602860-80f7-4802-b20f-8b53fb011013",
+                                               "errors": []
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @BadRequestErrorResponse
+    @UnauthorizedErrorResponse
+    @ForbiddenErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    public SharingAgreementResponse updateSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id,
+                                                            @Valid @RequestBody UpdateSharingAgreementBody body) {
+        SharingAgreement agreement = service.update(plantId, id, body.getName(), body.getNotes(),
+                body.getInstalledPowerKw());
+        return new SharingAgreementResponse(agreement);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementController.java
@@ -21,8 +21,8 @@ import org.lucoenergia.conluz.infrastructure.shared.web.error.RestError;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,12 +44,14 @@ public class UpdateSharingAgreementController {
         this.service = service;
     }
 
-    @PatchMapping
+    @PutMapping
     @Operation(
-            summary = "Updates a DRAFT sharing agreement's name, notes and installed power",
+            summary = "Replaces a DRAFT sharing agreement's name, notes and installed power",
             description = """
-                    This endpoint updates the name, notes and installed power of a sharing agreement.
-                    Its status, plant and creation metadata can never be changed through this endpoint.
+                    This endpoint replaces the name, notes and installed power of a sharing agreement.
+                    All three fields must be provided; this is a full replacement of the updatable
+                    fields, not a partial update. Its status, plant and creation metadata can never be
+                    changed through this endpoint.
 
                     **Required: Community Admin**
 
@@ -97,8 +99,7 @@ public class UpdateSharingAgreementController {
     @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
     public SharingAgreementResponse updateSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id,
                                                             @Valid @RequestBody UpdateSharingAgreementBody body) {
-        SharingAgreement agreement = service.update(plantId, id, body.getName(), body.getNotes(),
-                body.getInstalledPowerKw());
+        SharingAgreement agreement = service.update(plantId, id, body.mapToUpdateSharingAgreement());
         return new SharingAgreementResponse(agreement);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabase.java
@@ -2,6 +2,7 @@ package org.lucoenergia.conluz.infrastructure.production.plant.update;
 
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreement;
 import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementRepository;
 import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
 import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntityMapper;
@@ -9,7 +10,6 @@ import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.S
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Transactional
@@ -26,17 +26,16 @@ public class UpdateSharingAgreementRepositoryDatabase implements UpdateSharingAg
     }
 
     @Override
-    public SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes,
-                                    BigDecimal installedPowerKw) {
+    public SharingAgreement update(UUID plantId, UUID sharingAgreementId, UpdateSharingAgreement update) {
         SharingAgreementEntity entity = sharingAgreementRepository.findById(sharingAgreementId)
                 .orElseThrow(() -> new SharingAgreementNotFoundException(sharingAgreementId));
         if (!plantId.equals(entity.getPlant().getId())) {
             throw new SharingAgreementNotFoundException(sharingAgreementId);
         }
 
-        entity.setName(name);
-        entity.setNotes(notes);
-        entity.setInstalledPowerKw(installedPowerKw);
+        entity.setName(update.getName());
+        entity.setNotes(update.getNotes());
+        entity.setInstalledPowerKw(update.getInstalledPowerKw());
 
         return mapper.map(sharingAgreementRepository.save(entity));
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabase.java
@@ -1,0 +1,43 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntityMapper;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Transactional
+@Repository
+public class UpdateSharingAgreementRepositoryDatabase implements UpdateSharingAgreementRepository {
+
+    private final SharingAgreementRepository sharingAgreementRepository;
+    private final SharingAgreementEntityMapper mapper;
+
+    public UpdateSharingAgreementRepositoryDatabase(SharingAgreementRepository sharingAgreementRepository,
+                                                     SharingAgreementEntityMapper mapper) {
+        this.sharingAgreementRepository = sharingAgreementRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes,
+                                    BigDecimal installedPowerKw) {
+        SharingAgreementEntity entity = sharingAgreementRepository.findById(sharingAgreementId)
+                .orElseThrow(() -> new SharingAgreementNotFoundException(sharingAgreementId));
+        if (!plantId.equals(entity.getPlant().getId())) {
+            throw new SharingAgreementNotFoundException(sharingAgreementId);
+        }
+
+        entity.setName(name);
+        entity.setNotes(notes);
+        entity.setInstalledPowerKw(installedPowerKw);
+
+        return mapper.map(sharingAgreementRepository.save(entity));
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImpl.java
@@ -2,12 +2,12 @@ package org.lucoenergia.conluz.infrastructure.production.plant.update;
 
 import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreement;
 import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Transactional
@@ -24,10 +24,9 @@ public class UpdateSharingAgreementServiceImpl implements UpdateSharingAgreement
     }
 
     @Override
-    public SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes,
-                                    BigDecimal installedPowerKw) {
+    public SharingAgreement update(UUID plantId, UUID sharingAgreementId, UpdateSharingAgreement update) {
         SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
         agreement.assertDraft();
-        return repository.update(plantId, sharingAgreementId, name, notes, installedPowerKw);
+        return repository.update(plantId, sharingAgreementId, update);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImpl.java
@@ -1,0 +1,33 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Transactional
+@Service
+public class UpdateSharingAgreementServiceImpl implements UpdateSharingAgreementService {
+
+    private final GetSharingAgreementService getSharingAgreementService;
+    private final UpdateSharingAgreementRepository repository;
+
+    public UpdateSharingAgreementServiceImpl(GetSharingAgreementService getSharingAgreementService,
+                                              UpdateSharingAgreementRepository repository) {
+        this.getSharingAgreementService = getSharingAgreementService;
+        this.repository = repository;
+    }
+
+    @Override
+    public SharingAgreement update(UUID plantId, UUID sharingAgreementId, String name, String notes,
+                                    BigDecimal installedPowerKw) {
+        SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
+        agreement.assertDraft();
+        return repository.update(plantId, sharingAgreementId, name, notes, installedPowerKw);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorCode.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/shared/web/error/RestErrorCode.java
@@ -18,5 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Stable machine-readable error code.")
 public enum RestErrorCode {
 
-    USER_LAST_PLATFORM_ADMIN
+    USER_LAST_PLATFORM_ADMIN,
+    SHARING_AGREEMENT_NOT_DRAFT,
+    SHARING_AGREEMENT_HAS_NO_COEFFICIENTS
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -33,6 +33,8 @@ error.plant.already.exists=Plant with code ''{0}'' already exists.
 error.plant.not.found=Plant with ID ''{0}'' has not been found. Verify the ID is correct.
 error.sharing.agreement.not.found=Sharing agreement with ID ''{0}'' has not been found. Verify the ID is correct.
 error.sharing.agreement.file.not.found=File for sharing agreement with ID ''{0}'' has not been found. Verify the ID is correct.
+error.sharing.agreement.not.draft=Sharing agreement ''{0}'' is not in DRAFT status (currently ''{1}'').
+error.sharing.agreement.no.coefficients=Sharing agreement ''{0}'' cannot be published because it has no partition coefficients.
 # Huawei
 error.huawei.disabled=Huawei integration is disabled. Enable it via PUT /api/v1/production/huawei/config before triggering this operation.
 # Internal server error

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -33,6 +33,8 @@ error.plant.already.exists=La planta con código ''{0}'' ya existe.
 error.plant.not.found=La planta con identificador ''{0}'' no ha sido encontrada. Revise que el identificador sea correcto.
 error.sharing.agreement.not.found=El acuerdo de reparto con identificador ''{0}'' no ha sido encontrado. Revise que el identificador sea correcto.
 error.sharing.agreement.file.not.found=El fichero del acuerdo de reparto con identificador ''{0}'' no ha sido encontrado. Revise que el identificador sea correcto.
+error.sharing.agreement.not.draft=El acuerdo de reparto ''{0}'' no está en estado DRAFT (actualmente ''{1}'').
+error.sharing.agreement.no.coefficients=El acuerdo de reparto ''{0}'' no se puede publicar porque no tiene coeficientes de reparto.
 # Huawei
 error.huawei.disabled=La integración con Huawei está deshabilitada. Habilítela mediante PUT /api/v1/production/huawei/config antes de invocar esta operación.
 error.datadis.disabled=La integración con Datadis está deshabilitada. Habilítela mediante PUT /api/v1/consumption/datadis/config antes de invocar esta operación.

--- a/src/test/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreementTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/production/plant/sharingagreement/SharingAgreementTest.java
@@ -1,0 +1,46 @@
+package org.lucoenergia.conluz.domain.production.plant.sharingagreement;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SharingAgreementTest {
+
+    @Test
+    void assertDraft_doesNotThrow_whenStatusIsDraft() {
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(UUID.randomUUID())
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .build();
+
+        assertDoesNotThrow(agreement::assertDraft);
+    }
+
+    @Test
+    void assertDraft_throws_whenStatusIsPublished() {
+        UUID id = UUID.randomUUID();
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(id)
+                .withStatus(SharingAgreementStatus.PUBLISHED)
+                .build();
+
+        SharingAgreementNotDraftException exception =
+                assertThrows(SharingAgreementNotDraftException.class, agreement::assertDraft);
+        assertEquals(id, exception.getId());
+        assertEquals(SharingAgreementStatus.PUBLISHED, exception.getCurrentStatus());
+    }
+
+    @Test
+    void assertDraft_throws_whenStatusIsSuperseded() {
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(UUID.randomUUID())
+                .withStatus(SharingAgreementStatus.SUPERSEDED)
+                .build();
+
+        assertThrows(SharingAgreementNotDraftException.class, agreement::assertDraft);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/community/access/PlantAccessGuardImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/community/access/PlantAccessGuardImplTest.java
@@ -292,6 +292,141 @@ class PlantAccessGuardImplTest {
         assertTrue(guard().canReadSharingAgreement(plant.getId(), agreementId));
     }
 
+    // --- canManageSharingAgreement(plantId) ---
+
+    @Test
+    void canManageSharingAgreementForCreate_returnsFalse_whenNoAuthenticatedUser() {
+        when(helper.getCurrentUser()).thenReturn(Optional.empty());
+
+        assertFalse(guard().canManageSharingAgreement(UUID.randomUUID()));
+    }
+
+    @Test
+    void canManageSharingAgreementForCreate_returnsTrue_whenUserIsCommunityAdmin() {
+        Community community = CommunityMother.random().build();
+        UUID communityId = community.getId();
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+        Plant plant = new Plant.Builder().withId(UUID.randomUUID()).withSupply(supply).build();
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+        when(getPlantRepository.findById(PlantId.of(plant.getId()))).thenReturn(Optional.of(plant));
+        when(helper.hasMembershipInCommunity(user, communityId)).thenReturn(true);
+        when(helper.hasCommunityAdminRoleIn(user, communityId)).thenReturn(true);
+
+        assertTrue(guard().canManageSharingAgreement(plant.getId()));
+    }
+
+    @Test
+    void canManageSharingAgreementForCreate_returnsFalse_whenUserIsCommunityMember() {
+        Community community = CommunityMother.random().build();
+        UUID communityId = community.getId();
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+        Plant plant = new Plant.Builder().withId(UUID.randomUUID()).withSupply(supply).build();
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+        when(getPlantRepository.findById(PlantId.of(plant.getId()))).thenReturn(Optional.of(plant));
+        when(helper.hasMembershipInCommunity(user, communityId)).thenReturn(true);
+
+        assertFalse(guard().canManageSharingAgreement(plant.getId()));
+    }
+
+    @Test
+    void canManageSharingAgreementForCreate_throwsNotFound_whenPlantNotFound() {
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+
+        UUID plantId = UUID.randomUUID();
+        when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.empty());
+
+        assertThrows(PlantNotFoundException.class, () -> guard().canManageSharingAgreement(plantId));
+    }
+
+    // --- canManageSharingAgreement(plantId, sharingAgreementId) ---
+
+    @Test
+    void canManageSharingAgreementForWrite_returnsFalse_whenNoAuthenticatedUser() {
+        when(helper.getCurrentUser()).thenReturn(Optional.empty());
+
+        assertFalse(guard().canManageSharingAgreement(UUID.randomUUID(), UUID.randomUUID()));
+    }
+
+    @Test
+    void canManageSharingAgreementForWrite_throwsNotFound_whenPlantNotFound() {
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+
+        UUID plantId = UUID.randomUUID();
+        when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.empty());
+
+        assertThrows(PlantNotFoundException.class,
+                () -> guard().canManageSharingAgreement(plantId, UUID.randomUUID()));
+    }
+
+    @Test
+    void canManageSharingAgreementForWrite_throwsNotFound_whenAgreementBelongsToAnotherPlant() {
+        Community community = CommunityMother.random().build();
+        UUID communityId = community.getId();
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+        Plant plant = new Plant.Builder().withId(UUID.randomUUID()).withSupply(supply).build();
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+        when(helper.hasMembershipInCommunity(user, communityId)).thenReturn(true);
+        when(getPlantRepository.findById(PlantId.of(plant.getId()))).thenReturn(Optional.of(plant));
+
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withPlantId(UUID.randomUUID())
+                .build();
+        when(getSharingAgreementRepository.findById(agreementId)).thenReturn(Optional.of(agreement));
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> guard().canManageSharingAgreement(plant.getId(), agreementId));
+    }
+
+    @Test
+    void canManageSharingAgreementForWrite_returnsTrue_whenUserIsCommunityAdmin() {
+        Community community = CommunityMother.random().build();
+        UUID communityId = community.getId();
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+        Plant plant = new Plant.Builder().withId(UUID.randomUUID()).withSupply(supply).build();
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+        when(helper.hasMembershipInCommunity(user, communityId)).thenReturn(true);
+        when(getPlantRepository.findById(PlantId.of(plant.getId()))).thenReturn(Optional.of(plant));
+        when(helper.hasCommunityAdminRoleIn(user, communityId)).thenReturn(true);
+
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withPlantId(plant.getId())
+                .build();
+        when(getSharingAgreementRepository.findById(agreementId)).thenReturn(Optional.of(agreement));
+
+        assertTrue(guard().canManageSharingAgreement(plant.getId(), agreementId));
+    }
+
+    @Test
+    void canManageSharingAgreementForWrite_returnsFalse_whenUserIsCommunityMember() {
+        Community community = CommunityMother.random().build();
+        UUID communityId = community.getId();
+        Supply supply = supplyInCommunity(UUID.randomUUID(), community);
+        Plant plant = new Plant.Builder().withId(UUID.randomUUID()).withSupply(supply).build();
+        User user = UserMother.randomUser();
+        when(helper.getCurrentUser()).thenReturn(Optional.of(user));
+        when(helper.hasMembershipInCommunity(user, communityId)).thenReturn(true);
+        when(getPlantRepository.findById(PlantId.of(plant.getId()))).thenReturn(Optional.of(plant));
+
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement agreement = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withPlantId(plant.getId())
+                .build();
+        when(getSharingAgreementRepository.findById(agreementId)).thenReturn(Optional.of(agreement));
+
+        assertFalse(guard().canManageSharingAgreement(plant.getId(), agreementId));
+    }
+
     // --- canListPlants ---
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementControllerTest.java
@@ -1,0 +1,131 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class CreateSharingAgreementControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private CreateUserRepository createUserRepository;
+    @Autowired
+    private CreateCommunityRepository createCommunityRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreatePlantRepository createPlantRepository;
+
+    private Community communityA;
+    private Community communityB;
+    private Plant plantA;
+
+    @BeforeEach
+    void setUp() {
+        communityA = createCommunityRepository.create(CommunityMother.random().build());
+        communityB = createCommunityRepository.create(CommunityMother.random().build());
+        plantA = createPlant(communityA);
+    }
+
+    @Test
+    void returnsUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(post(url(plantA.getId()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"2024 winter distribution\"}"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void returnsForbiddenForCommunityMember() throws Exception {
+        String authHeader = loginAsCommunityMember(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"2024 winter distribution\"}"))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void returnsNotFoundForCrossCommunityAdmin() throws Exception {
+        // An admin of a different community cannot see plantA -> 404, not 403.
+        String authHeader = loginAsCommunityAdmin(communityB.getId());
+
+        mockMvc.perform(post(url(plantA.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"2024 winter distribution\"}"))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsBadRequestWhenNameIsBlank() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\"}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createsDraftAgreementWithSnapshottedPowerAndCreator() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"2024 winter distribution\",\"notes\":\"initial\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plantId").value(plantA.getId().toString()))
+                .andExpect(jsonPath("$.name").value("2024 winter distribution"))
+                .andExpect(jsonPath("$.notes").value("initial"))
+                .andExpect(jsonPath("$.status").value("DRAFT"))
+                .andExpect(jsonPath("$.installedPowerKw").value(BigDecimal.valueOf(plantA.getTotalPower()).doubleValue()))
+                .andExpect(jsonPath("$.createdBy").isNotEmpty());
+    }
+
+    private Plant createPlant(Community community) {
+        User owner = UserMother.randomUser();
+        createUserRepository.create(owner);
+        Supply supply = SupplyMother.random(owner).build();
+        supply = createSupplyRepository.create(supply, UserId.of(owner.getId()), community.getId());
+        Plant plant = PlantMother.random(supply).build();
+        return createPlantRepository.create(plant, SupplyId.of(supply.getId()));
+    }
+
+    private String url(java.util.UUID plantId) {
+        return "/api/v1/plants/" + plantId + "/sharing-agreements";
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementRepositoryDatabaseTest.java
@@ -1,0 +1,94 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
+
+@Transactional
+class CreateSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
+
+    @Autowired
+    private CreateSharingAgreementRepositoryDatabase repository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SupplyRepository supplyRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CommunityJpaRepository communityJpaRepository;
+
+    private PlantEntity persistPlant() {
+        UserEntity user = UserMother.randomUserEntity();
+        userRepository.save(user);
+        SupplyEntity supply = supplyRepository.save(SupplyEntityMother.random(
+                user, communityJpaRepository.getReferenceById(DEFAULT_COMMUNITY_ID)));
+        return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supply).build());
+    }
+
+    @Test
+    void create_persistsAgreementLinkedToPlant() {
+        PlantEntity plant = persistPlant();
+        UUID agreementId = UUID.randomUUID();
+        UUID createdBy = UUID.randomUUID();
+        SharingAgreement toCreate = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withPlantId(plant.getId())
+                .withName("2024 winter distribution")
+                .withNotes("initial")
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .withInstalledPowerKw(BigDecimal.valueOf(12.5))
+                .withCreatedAt(Instant.now())
+                .withCreatedBy(createdBy)
+                .build();
+
+        SharingAgreement result = repository.create(toCreate);
+
+        assertEquals(agreementId, result.getId());
+        assertEquals(plant.getId(), result.getPlantId());
+        assertEquals("2024 winter distribution", result.getName());
+        assertEquals(SharingAgreementStatus.DRAFT, result.getStatus());
+        assertEquals(0, BigDecimal.valueOf(12.5).compareTo(result.getInstalledPowerKw()));
+        assertEquals(createdBy, result.getCreatedBy());
+        assertTrue(sharingAgreementRepository.findById(agreementId).isPresent());
+    }
+
+    @Test
+    void create_throwsPlantNotFound_whenPlantDoesNotExist() {
+        SharingAgreement toCreate = new SharingAgreement.Builder()
+                .withId(UUID.randomUUID())
+                .withPlantId(UUID.randomUUID())
+                .withName("Orphan agreement")
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .withCreatedAt(Instant.now())
+                .build();
+
+        assertThrows(PlantNotFoundException.class, () -> repository.create(toCreate));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/create/CreateSharingAgreementServiceImplTest.java
@@ -1,0 +1,66 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.create;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.create.CreateSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.get.GetPlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.shared.PlantId;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateSharingAgreementServiceImplTest {
+
+    @Mock
+    private GetPlantRepository getPlantRepository;
+    @Mock
+    private CreateSharingAgreementRepository repository;
+
+    private CreateSharingAgreementServiceImpl service() {
+        return new CreateSharingAgreementServiceImpl(getPlantRepository, repository);
+    }
+
+    @Test
+    void create_throwsPlantNotFound_whenPlantDoesNotExist() {
+        UUID plantId = UUID.randomUUID();
+        when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.empty());
+
+        assertThrows(PlantNotFoundException.class,
+                () -> service().create(plantId, "name", "notes", UUID.randomUUID()));
+    }
+
+    @Test
+    void create_buildsDraftAgreementSnapshottingPlantPower() {
+        UUID plantId = UUID.randomUUID();
+        UUID createdBy = UUID.randomUUID();
+        Plant plant = PlantMother.random().withId(plantId).withTotalPower(7.25).build();
+        when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.of(plant));
+        when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SharingAgreement result = service().create(plantId, "2024 winter distribution", "notes", createdBy);
+
+        assertEquals(plantId, result.getPlantId());
+        assertEquals("2024 winter distribution", result.getName());
+        assertEquals("notes", result.getNotes());
+        assertEquals(SharingAgreementStatus.DRAFT, result.getStatus());
+        assertEquals(0, BigDecimal.valueOf(7.25).compareTo(result.getInstalledPowerKw()));
+        assertEquals(createdBy, result.getCreatedBy());
+        assertNotNull(result.getId());
+        assertNotNull(result.getCreatedAt());
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementControllerTest.java
@@ -1,0 +1,171 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.delete;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class DeleteSharingAgreementControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private CreateUserRepository createUserRepository;
+    @Autowired
+    private CreateCommunityRepository createCommunityRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+
+    private Community communityA;
+    private Community communityB;
+    private Plant plantA;
+    private Plant otherPlantInCommunityA;
+    private SharingAgreementEntity draftAgreement;
+
+    @BeforeEach
+    void setUp() {
+        communityA = createCommunityRepository.create(CommunityMother.random().build());
+        communityB = createCommunityRepository.create(CommunityMother.random().build());
+        plantA = createPlant(communityA);
+        otherPlantInCommunityA = createPlant(communityA);
+        draftAgreement = createAgreement(plantA, SharingAgreementStatus.DRAFT);
+    }
+
+    @Test
+    void returnsUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(delete(url(plantA.getId(), draftAgreement.getId()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void returnsForbiddenForCommunityMember() throws Exception {
+        String authHeader = loginAsCommunityMember(communityA.getId());
+
+        mockMvc.perform(delete(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void returnsNotFoundForCrossCommunityAdmin() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityB.getId());
+
+        mockMvc.perform(delete(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsNotFoundWhenAgreementBelongsToAnotherPlantOfTheSameCommunity() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(delete(url(otherPlantInCommunityA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsConflictWhenAgreementIsPublished() throws Exception {
+        SharingAgreementEntity published = createAgreement(plantA, SharingAgreementStatus.PUBLISHED);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(delete(url(plantA.getId(), published.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isConflict());
+        Assertions.assertTrue(sharingAgreementRepository.findById(published.getId()).isPresent());
+    }
+
+    @Test
+    void returnsConflictWhenAgreementIsSuperseded() throws Exception {
+        SharingAgreementEntity superseded = createAgreement(plantA, SharingAgreementStatus.SUPERSEDED);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(delete(url(plantA.getId(), superseded.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void deletesDraftAgreement() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(delete(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+        Assertions.assertTrue(sharingAgreementRepository.findById(draftAgreement.getId()).isEmpty());
+    }
+
+    private Plant createPlant(Community community) {
+        User owner = UserMother.randomUser();
+        createUserRepository.create(owner);
+        Supply supply = SupplyMother.random(owner).build();
+        supply = createSupplyRepository.create(supply, UserId.of(owner.getId()), community.getId());
+        Plant plant = PlantMother.random(supply).build();
+        return createPlantRepository.create(plant, SupplyId.of(supply.getId()));
+    }
+
+    private SharingAgreementEntity createAgreement(Plant plant, SharingAgreementStatus status) {
+        PlantEntity plantEntity = plantRepository.getReferenceById(plant.getId());
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plantEntity);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(status);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    private String url(UUID plantId, UUID agreementId) {
+        return "/api/v1/plants/" + plantId + "/sharing-agreements/" + agreementId;
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementRepositoryDatabaseTest.java
@@ -1,0 +1,92 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.delete;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
+
+@Transactional
+class DeleteSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
+
+    @Autowired
+    private DeleteSharingAgreementRepositoryDatabase repository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SupplyRepository supplyRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CommunityJpaRepository communityJpaRepository;
+
+    private PlantEntity persistPlant() {
+        UserEntity user = UserMother.randomUserEntity();
+        userRepository.save(user);
+        SupplyEntity supply = supplyRepository.save(SupplyEntityMother.random(
+                user, communityJpaRepository.getReferenceById(DEFAULT_COMMUNITY_ID)));
+        return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supply).build());
+    }
+
+    private SharingAgreementEntity persistAgreement(PlantEntity plant) {
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plant);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(SharingAgreementStatus.DRAFT);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    @Test
+    void delete_removesTheAgreement() {
+        PlantEntity plant = persistPlant();
+        SharingAgreementEntity entity = persistAgreement(plant);
+
+        repository.delete(plant.getId(), entity.getId());
+
+        assertTrue(sharingAgreementRepository.findById(entity.getId()).isEmpty());
+    }
+
+    @Test
+    void delete_throwsNotFound_whenAgreementBelongsToAnotherPlant() {
+        PlantEntity plantA = persistPlant();
+        PlantEntity plantB = persistPlant();
+        SharingAgreementEntity entity = persistAgreement(plantA);
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> repository.delete(plantB.getId(), entity.getId()));
+        assertTrue(sharingAgreementRepository.findById(entity.getId()).isPresent());
+    }
+
+    @Test
+    void delete_throwsNotFound_whenAgreementDoesNotExist() {
+        PlantEntity plant = persistPlant();
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> repository.delete(plant.getId(), UUID.randomUUID()));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeleteSharingAgreementServiceImplTest.java
@@ -1,0 +1,60 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.delete;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.production.plant.delete.DeleteSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteSharingAgreementServiceImplTest {
+
+    @Mock
+    private GetSharingAgreementService getSharingAgreementService;
+    @Mock
+    private DeleteSharingAgreementRepository repository;
+
+    private DeleteSharingAgreementServiceImpl service() {
+        return new DeleteSharingAgreementServiceImpl(getSharingAgreementService, repository);
+    }
+
+    @Test
+    void delete_throwsNotDraft_andNeverDeletes_whenAgreementIsPublished() {
+        UUID plantId = UUID.randomUUID();
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement published = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.PUBLISHED)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(published);
+
+        assertThrows(SharingAgreementNotDraftException.class, () -> service().delete(plantId, agreementId));
+        verify(repository, never()).delete(plantId, agreementId);
+    }
+
+    @Test
+    void delete_delegatesToRepository_whenAgreementIsDraft() {
+        UUID plantId = UUID.randomUUID();
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement draft = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
+
+        service().delete(plantId, agreementId);
+
+        verify(repository).delete(plantId, agreementId);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementControllerTest.java
@@ -1,0 +1,201 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.publish;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class PublishSharingAgreementControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private CreateUserRepository createUserRepository;
+    @Autowired
+    private CreateCommunityRepository createCommunityRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SupplyRepository supplyRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+    @Autowired
+    private SupplyPartitionCoefficientJpaRepository supplyPartitionCoefficientJpaRepository;
+
+    private Community communityA;
+    private Community communityB;
+    private Plant plantA;
+    private Supply supplyA;
+    private Plant otherPlantInCommunityA;
+    private SharingAgreementEntity draftAgreement;
+
+    @BeforeEach
+    void setUp() {
+        communityA = createCommunityRepository.create(CommunityMother.random().build());
+        communityB = createCommunityRepository.create(CommunityMother.random().build());
+        supplyA = createSupply(communityA);
+        plantA = createPlant(supplyA);
+        otherPlantInCommunityA = createPlant(createSupply(communityA));
+        draftAgreement = createAgreement(plantA, SharingAgreementStatus.DRAFT);
+    }
+
+    @Test
+    void returnsUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void returnsForbiddenForCommunityMember() throws Exception {
+        String authHeader = loginAsCommunityMember(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void returnsNotFoundForCrossCommunityAdmin() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityB.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsNotFoundWhenAgreementBelongsToAnotherPlantOfTheSameCommunity() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(otherPlantInCommunityA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsConflictWhenAgreementIsNotDraft() throws Exception {
+        SharingAgreementEntity published = createAgreement(plantA, SharingAgreementStatus.PUBLISHED);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), published.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void returnsConflictWhenAgreementHasNoCoefficients() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void publishesDraftAgreementWithCoefficients() throws Exception {
+        seedCoefficient(supplyA, plantA, draftAgreement);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(draftAgreement.getId().toString()))
+                .andExpect(jsonPath("$.status").value("PUBLISHED"));
+    }
+
+    private Supply createSupply(Community community) {
+        User owner = UserMother.randomUser();
+        createUserRepository.create(owner);
+        Supply supply = SupplyMother.random(owner).build();
+        return createSupplyRepository.create(supply, UserId.of(owner.getId()), community.getId());
+    }
+
+    private Plant createPlant(Supply supply) {
+        Plant plant = PlantMother.random(supply).build();
+        return createPlantRepository.create(plant, SupplyId.of(supply.getId()));
+    }
+
+    private SharingAgreementEntity createAgreement(Plant plant, SharingAgreementStatus status) {
+        PlantEntity plantEntity = plantRepository.getReferenceById(plant.getId());
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plantEntity);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(status);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    private void seedCoefficient(Supply supply, Plant plant, SharingAgreementEntity agreement) {
+        SupplyEntity supplyEntity = supplyRepository.getReferenceById(supply.getId());
+        PlantEntity plantEntity = plantRepository.getReferenceById(plant.getId());
+        SharingAgreementEntity agreementReference = sharingAgreementRepository.getReferenceById(agreement.getId());
+
+        SupplyPartitionCoefficientEntity coefficient = new SupplyPartitionCoefficientEntity();
+        coefficient.setId(UUID.randomUUID());
+        coefficient.setSupply(supplyEntity);
+        coefficient.setPlant(plantEntity);
+        coefficient.setSharingAgreement(agreementReference);
+        coefficient.setCoefficient(BigDecimal.ONE);
+        coefficient.setValidFrom(Instant.now());
+        coefficient.setCreatedAt(Instant.now());
+        supplyPartitionCoefficientJpaRepository.save(coefficient);
+    }
+
+    private String url(UUID plantId, UUID agreementId) {
+        return "/api/v1/plants/" + plantId + "/sharing-agreements/" + agreementId + "/publish";
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementRepositoryDatabaseTest.java
@@ -1,0 +1,94 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.publish;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
+
+@Transactional
+class PublishSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
+
+    @Autowired
+    private PublishSharingAgreementRepositoryDatabase repository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SupplyRepository supplyRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CommunityJpaRepository communityJpaRepository;
+
+    private PlantEntity persistPlant() {
+        UserEntity user = UserMother.randomUserEntity();
+        userRepository.save(user);
+        SupplyEntity supply = supplyRepository.save(SupplyEntityMother.random(
+                user, communityJpaRepository.getReferenceById(DEFAULT_COMMUNITY_ID)));
+        return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supply).build());
+    }
+
+    private SharingAgreementEntity persistAgreement(PlantEntity plant, SharingAgreementStatus status) {
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plant);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(status);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    @Test
+    void publish_transitionsDraftToPublished() {
+        PlantEntity plant = persistPlant();
+        SharingAgreementEntity entity = persistAgreement(plant, SharingAgreementStatus.DRAFT);
+
+        SharingAgreement result = repository.publish(plant.getId(), entity.getId());
+
+        assertEquals(SharingAgreementStatus.PUBLISHED, result.getStatus());
+        assertEquals(SharingAgreementStatus.PUBLISHED,
+                sharingAgreementRepository.findById(entity.getId()).orElseThrow().getStatus());
+    }
+
+    @Test
+    void publish_throwsNotFound_whenAgreementBelongsToAnotherPlant() {
+        PlantEntity plantA = persistPlant();
+        PlantEntity plantB = persistPlant();
+        SharingAgreementEntity entity = persistAgreement(plantA, SharingAgreementStatus.DRAFT);
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> repository.publish(plantB.getId(), entity.getId()));
+    }
+
+    @Test
+    void publish_throwsNotFound_whenAgreementDoesNotExist() {
+        PlantEntity plant = persistPlant();
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> repository.publish(plant.getId(), UUID.randomUUID()));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/publish/PublishSharingAgreementServiceImplTest.java
@@ -1,0 +1,87 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.publish;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.publish.PublishSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementHasNoCoefficientsException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PublishSharingAgreementServiceImplTest {
+
+    @Mock
+    private GetSharingAgreementService getSharingAgreementService;
+    @Mock
+    private SupplyPartitionCoefficientRepository supplyPartitionCoefficientRepository;
+    @Mock
+    private PublishSharingAgreementRepository repository;
+
+    private PublishSharingAgreementServiceImpl service() {
+        return new PublishSharingAgreementServiceImpl(getSharingAgreementService, supplyPartitionCoefficientRepository, repository);
+    }
+
+    @Test
+    void publish_throwsNotDraft_whenAgreementIsPublished() {
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement published = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.PUBLISHED)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(published);
+
+        assertThrows(SharingAgreementNotDraftException.class, () -> service().publish(UUID.randomUUID(), agreementId));
+        verify(supplyPartitionCoefficientRepository, never()).existsBySharingAgreementId(agreementId);
+    }
+
+    @Test
+    void publish_throwsHasNoCoefficients_whenNoCoefficientsExist() {
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement draft = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
+        when(supplyPartitionCoefficientRepository.existsBySharingAgreementId(agreementId)).thenReturn(false);
+
+        assertThrows(SharingAgreementHasNoCoefficientsException.class,
+                () -> service().publish(UUID.randomUUID(), agreementId));
+        verify(repository, never()).publish(any(), any());
+    }
+
+    @Test
+    void publish_delegatesToRepository_whenDraftWithCoefficients() {
+        UUID plantId = UUID.randomUUID();
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement draft = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
+        when(supplyPartitionCoefficientRepository.existsBySharingAgreementId(agreementId)).thenReturn(true);
+        SharingAgreement published = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.PUBLISHED)
+                .build();
+        when(repository.publish(plantId, agreementId)).thenReturn(published);
+
+        SharingAgreement result = service().publish(plantId, agreementId);
+
+        assertEquals(SharingAgreementStatus.PUBLISHED, result.getStatus());
+        verify(repository).publish(plantId, agreementId);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.util.UUID;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,7 +68,7 @@ class UpdateSharingAgreementControllerTest extends BaseControllerTest {
 
     @Test
     void returnsUnauthorizedWithoutToken() throws Exception {
-        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+        mockMvc.perform(put(url(plantA.getId(), draftAgreement.getId()))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body("New name", "5.5")))
                 .andDo(print())
@@ -79,7 +79,7 @@ class UpdateSharingAgreementControllerTest extends BaseControllerTest {
     void returnsForbiddenForCommunityMember() throws Exception {
         String authHeader = loginAsCommunityMember(communityA.getId());
 
-        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+        mockMvc.perform(put(url(plantA.getId(), draftAgreement.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body("New name", "5.5")))
@@ -91,7 +91,7 @@ class UpdateSharingAgreementControllerTest extends BaseControllerTest {
     void returnsNotFoundForCrossCommunityAdmin() throws Exception {
         String authHeader = loginAsCommunityAdmin(communityB.getId());
 
-        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+        mockMvc.perform(put(url(plantA.getId(), draftAgreement.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body("New name", "5.5")))
@@ -103,7 +103,7 @@ class UpdateSharingAgreementControllerTest extends BaseControllerTest {
     void returnsNotFoundWhenAgreementBelongsToAnotherPlantOfTheSameCommunity() throws Exception {
         String authHeader = loginAsCommunityAdmin(communityA.getId());
 
-        mockMvc.perform(patch(url(otherPlantInCommunityA.getId(), draftAgreement.getId()))
+        mockMvc.perform(put(url(otherPlantInCommunityA.getId(), draftAgreement.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body("New name", "5.5")))
@@ -112,11 +112,23 @@ class UpdateSharingAgreementControllerTest extends BaseControllerTest {
     }
 
     @Test
+    void returnsBadRequestWhenInstalledPowerKwIsMissing() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(put(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"New name\"}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void returnsConflictWhenAgreementIsNotDraft() throws Exception {
         SharingAgreementEntity published = createAgreement(plantA, SharingAgreementStatus.PUBLISHED);
         String authHeader = loginAsCommunityAdmin(communityA.getId());
 
-        mockMvc.perform(patch(url(plantA.getId(), published.getId()))
+        mockMvc.perform(put(url(plantA.getId(), published.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body("New name", "5.5")))
@@ -129,7 +141,7 @@ class UpdateSharingAgreementControllerTest extends BaseControllerTest {
         String authHeader = loginAsCommunityAdmin(communityA.getId());
         Instant originalCreatedAt = draftAgreement.getCreatedAt();
 
-        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+        mockMvc.perform(put(url(plantA.getId(), draftAgreement.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body("Updated name", "9.75")))

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementControllerTest.java
@@ -1,0 +1,179 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.Community;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.SupplyMother;
+import org.lucoenergia.conluz.domain.admin.supply.create.CreateSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.user.User;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.admin.user.create.CreateUserRepository;
+import org.lucoenergia.conluz.domain.production.plant.Plant;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.create.CreatePlantRepository;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.shared.SupplyId;
+import org.lucoenergia.conluz.domain.shared.UserId;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class UpdateSharingAgreementControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private CreateUserRepository createUserRepository;
+    @Autowired
+    private CreateCommunityRepository createCommunityRepository;
+    @Autowired
+    private CreateSupplyRepository createSupplyRepository;
+    @Autowired
+    private CreatePlantRepository createPlantRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+
+    private Community communityA;
+    private Community communityB;
+    private Plant plantA;
+    private Plant otherPlantInCommunityA;
+    private SharingAgreementEntity draftAgreement;
+
+    @BeforeEach
+    void setUp() {
+        communityA = createCommunityRepository.create(CommunityMother.random().build());
+        communityB = createCommunityRepository.create(CommunityMother.random().build());
+        plantA = createPlant(communityA);
+        otherPlantInCommunityA = createPlant(communityA);
+        draftAgreement = createAgreement(plantA, SharingAgreementStatus.DRAFT);
+    }
+
+    @Test
+    void returnsUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body("New name", "5.5")))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void returnsForbiddenForCommunityMember() throws Exception {
+        String authHeader = loginAsCommunityMember(communityA.getId());
+
+        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body("New name", "5.5")))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void returnsNotFoundForCrossCommunityAdmin() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityB.getId());
+
+        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body("New name", "5.5")))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsNotFoundWhenAgreementBelongsToAnotherPlantOfTheSameCommunity() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(patch(url(otherPlantInCommunityA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body("New name", "5.5")))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsConflictWhenAgreementIsNotDraft() throws Exception {
+        SharingAgreementEntity published = createAgreement(plantA, SharingAgreementStatus.PUBLISHED);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(patch(url(plantA.getId(), published.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body("New name", "5.5")))
+                .andDo(print())
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void updatesOnlyDescriptiveFields() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+        Instant originalCreatedAt = draftAgreement.getCreatedAt();
+
+        mockMvc.perform(patch(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body("Updated name", "9.75")))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(draftAgreement.getId().toString()))
+                .andExpect(jsonPath("$.plantId").value(plantA.getId().toString()))
+                .andExpect(jsonPath("$.name").value("Updated name"))
+                .andExpect(jsonPath("$.installedPowerKw").value(9.75))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+
+        SharingAgreementEntity persisted = sharingAgreementRepository.findById(draftAgreement.getId()).orElseThrow();
+        org.junit.jupiter.api.Assertions.assertEquals(plantA.getId(), persisted.getPlant().getId());
+        org.junit.jupiter.api.Assertions.assertEquals(originalCreatedAt, persisted.getCreatedAt());
+        org.junit.jupiter.api.Assertions.assertNull(persisted.getCreatedBy());
+        org.junit.jupiter.api.Assertions.assertEquals(SharingAgreementStatus.DRAFT, persisted.getStatus());
+    }
+
+    private Plant createPlant(Community community) {
+        User owner = UserMother.randomUser();
+        createUserRepository.create(owner);
+        Supply supply = SupplyMother.random(owner).build();
+        supply = createSupplyRepository.create(supply, UserId.of(owner.getId()), community.getId());
+        Plant plant = PlantMother.random(supply).build();
+        return createPlantRepository.create(plant, SupplyId.of(supply.getId()));
+    }
+
+    private SharingAgreementEntity createAgreement(Plant plant, SharingAgreementStatus status) {
+        PlantEntity plantEntity = plantRepository.getReferenceById(plant.getId());
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plantEntity);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(status);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    private String body(String name, String installedPowerKw) {
+        return "{\"name\":\"" + name + "\",\"installedPowerKw\":" + installedPowerKw + "}";
+    }
+
+    private String url(UUID plantId, UUID agreementId) {
+        return "/api/v1/plants/" + plantId + "/sharing-agreements/" + agreementId;
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabaseTest.java
@@ -1,0 +1,98 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
+
+@Transactional
+class UpdateSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
+
+    @Autowired
+    private UpdateSharingAgreementRepositoryDatabase repository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SupplyRepository supplyRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CommunityJpaRepository communityJpaRepository;
+
+    private PlantEntity persistPlant() {
+        UserEntity user = UserMother.randomUserEntity();
+        userRepository.save(user);
+        SupplyEntity supply = supplyRepository.save(SupplyEntityMother.random(
+                user, communityJpaRepository.getReferenceById(DEFAULT_COMMUNITY_ID)));
+        return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supply).build());
+    }
+
+    private SharingAgreementEntity persistAgreement(PlantEntity plant) {
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plant);
+        agreement.setName("Original name");
+        agreement.setStatus(SharingAgreementStatus.DRAFT);
+        agreement.setCreatedAt(Instant.now());
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    @Test
+    void update_changesOnlyDescriptiveFields() {
+        PlantEntity plant = persistPlant();
+        SharingAgreementEntity entity = persistAgreement(plant);
+
+        SharingAgreement result = repository.update(plant.getId(), entity.getId(), "New name", "New notes",
+                BigDecimal.valueOf(9.5));
+
+        assertEquals("New name", result.getName());
+        assertEquals("New notes", result.getNotes());
+        assertEquals(0, BigDecimal.valueOf(9.5).compareTo(result.getInstalledPowerKw()));
+        assertEquals(SharingAgreementStatus.DRAFT, result.getStatus());
+        assertEquals(plant.getId(), result.getPlantId());
+    }
+
+    @Test
+    void update_throwsNotFound_whenAgreementBelongsToAnotherPlant() {
+        PlantEntity plantA = persistPlant();
+        PlantEntity plantB = persistPlant();
+        SharingAgreementEntity entity = persistAgreement(plantA);
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> repository.update(plantB.getId(), entity.getId(), "New name", "New notes", BigDecimal.ONE));
+    }
+
+    @Test
+    void update_throwsNotFound_whenAgreementDoesNotExist() {
+        PlantEntity plant = persistPlant();
+
+        assertThrows(SharingAgreementNotFoundException.class,
+                () -> repository.update(plant.getId(), UUID.randomUUID(), "New name", "New notes", BigDecimal.ONE));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementRepositoryDatabaseTest.java
@@ -6,6 +6,7 @@ import org.lucoenergia.conluz.domain.production.plant.PlantMother;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotFoundException;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreement;
 import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
@@ -63,13 +64,21 @@ class UpdateSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
         return sharingAgreementRepository.save(agreement);
     }
 
+    private UpdateSharingAgreement anUpdate(String name, String notes, BigDecimal installedPowerKw) {
+        return new UpdateSharingAgreement.Builder()
+                .withName(name)
+                .withNotes(notes)
+                .withInstalledPowerKw(installedPowerKw)
+                .build();
+    }
+
     @Test
     void update_changesOnlyDescriptiveFields() {
         PlantEntity plant = persistPlant();
         SharingAgreementEntity entity = persistAgreement(plant);
 
-        SharingAgreement result = repository.update(plant.getId(), entity.getId(), "New name", "New notes",
-                BigDecimal.valueOf(9.5));
+        SharingAgreement result = repository.update(plant.getId(), entity.getId(),
+                anUpdate("New name", "New notes", BigDecimal.valueOf(9.5)));
 
         assertEquals("New name", result.getName());
         assertEquals("New notes", result.getNotes());
@@ -85,7 +94,8 @@ class UpdateSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
         SharingAgreementEntity entity = persistAgreement(plantA);
 
         assertThrows(SharingAgreementNotFoundException.class,
-                () -> repository.update(plantB.getId(), entity.getId(), "New name", "New notes", BigDecimal.ONE));
+                () -> repository.update(plantB.getId(), entity.getId(),
+                        anUpdate("New name", "New notes", BigDecimal.ONE)));
     }
 
     @Test
@@ -93,6 +103,7 @@ class UpdateSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
         PlantEntity plant = persistPlant();
 
         assertThrows(SharingAgreementNotFoundException.class,
-                () -> repository.update(plant.getId(), UUID.randomUUID(), "New name", "New notes", BigDecimal.ONE));
+                () -> repository.update(plant.getId(), UUID.randomUUID(),
+                        anUpdate("New name", "New notes", BigDecimal.ONE)));
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImplTest.java
@@ -1,0 +1,63 @@
+package org.lucoenergia.conluz.infrastructure.production.plant.update;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException;
+import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementRepository;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateSharingAgreementServiceImplTest {
+
+    @Mock
+    private GetSharingAgreementService getSharingAgreementService;
+    @Mock
+    private UpdateSharingAgreementRepository repository;
+
+    private UpdateSharingAgreementServiceImpl service() {
+        return new UpdateSharingAgreementServiceImpl(getSharingAgreementService, repository);
+    }
+
+    @Test
+    void update_throwsNotDraft_whenAgreementIsPublished() {
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement published = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.PUBLISHED)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(published);
+
+        assertThrows(SharingAgreementNotDraftException.class,
+                () -> service().update(UUID.randomUUID(), agreementId, "name", "notes", BigDecimal.TEN));
+    }
+
+    @Test
+    void update_delegatesToRepository_whenAgreementIsDraft() {
+        UUID plantId = UUID.randomUUID();
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement draft = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
+        SharingAgreement updated = new SharingAgreement.Builder().withId(agreementId).build();
+        when(repository.update(plantId, agreementId, "name", "notes", BigDecimal.TEN)).thenReturn(updated);
+
+        SharingAgreement result = service().update(plantId, agreementId, "name", "notes", BigDecimal.TEN);
+
+        assertEquals(updated, result);
+        verify(repository).update(plantId, agreementId, "name", "notes", BigDecimal.TEN);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdateSharingAgreementServiceImplTest.java
@@ -6,6 +6,7 @@ import org.lucoenergia.conluz.domain.production.plant.get.GetSharingAgreementSer
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreement;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementNotDraftException;
 import org.lucoenergia.conluz.domain.production.plant.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreement;
 import org.lucoenergia.conluz.domain.production.plant.update.UpdateSharingAgreementRepository;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +31,14 @@ class UpdateSharingAgreementServiceImplTest {
         return new UpdateSharingAgreementServiceImpl(getSharingAgreementService, repository);
     }
 
+    private UpdateSharingAgreement anUpdate() {
+        return new UpdateSharingAgreement.Builder()
+                .withName("name")
+                .withNotes("notes")
+                .withInstalledPowerKw(BigDecimal.TEN)
+                .build();
+    }
+
     @Test
     void update_throwsNotDraft_whenAgreementIsPublished() {
         UUID agreementId = UUID.randomUUID();
@@ -40,7 +49,7 @@ class UpdateSharingAgreementServiceImplTest {
         when(getSharingAgreementService.findById(agreementId)).thenReturn(published);
 
         assertThrows(SharingAgreementNotDraftException.class,
-                () -> service().update(UUID.randomUUID(), agreementId, "name", "notes", BigDecimal.TEN));
+                () -> service().update(UUID.randomUUID(), agreementId, anUpdate()));
     }
 
     @Test
@@ -52,12 +61,13 @@ class UpdateSharingAgreementServiceImplTest {
                 .withStatus(SharingAgreementStatus.DRAFT)
                 .build();
         when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
+        UpdateSharingAgreement update = anUpdate();
         SharingAgreement updated = new SharingAgreement.Builder().withId(agreementId).build();
-        when(repository.update(plantId, agreementId, "name", "notes", BigDecimal.TEN)).thenReturn(updated);
+        when(repository.update(plantId, agreementId, update)).thenReturn(updated);
 
-        SharingAgreement result = service().update(plantId, agreementId, "name", "notes", BigDecimal.TEN);
+        SharingAgreement result = service().update(plantId, agreementId, update);
 
         assertEquals(updated, result);
-        verify(repository).update(plantId, agreementId, "name", "notes", BigDecimal.TEN);
+        verify(repository).update(plantId, agreementId, update);
     }
 }


### PR DESCRIPTION
## Summary
- Adds the write side of the `SharingAgreement` aggregate on top of phase 5a's read stack: `POST`, `PATCH`, `DELETE`, and `POST .../publish` under `/api/v1/plants/{plantId}/sharing-agreements`, all `COMMUNITY_ADMIN`-scoped via new `canManageSharingAgreement` guard methods that preserve 5a's 404-before-403 IDOR protection.
- Enforces DRAFT-only mutation **in the domain** (`SharingAgreement.assertDraft()`, reused by patch/delete/publish) so a `PUBLISHED` agreement's data — including the `installedPowerKw` snapshot used as the historical billing basis — can never silently drift, and so a published agreement can't be deleted.
- `POST` snapshots `installedPowerKw` from the plant's current `totalPower` at creation time (not a live join) and always sets a non-null `createdBy` from the acting admin.
- `publish` additionally requires at least one existing partition-coefficient row, reusing the existing `SupplyPartitionCoefficient` repository stack (read-only `existsBySharingAgreementId`) rather than adding a parallel table access path.
- New `409 Conflict` responses (`SharingAgreementNotDraftException`, `SharingAgreementHasNoCoefficientsException`) wired into `PlantExceptionHandler` with matching `RestErrorCode` values and EN/ES i18n messages.

## Out of scope (deferred to phase 5c)
- `POST .../file` (upload) and `PUT .../partition-coefficients` (coefficient materialization) — not built/wired.
- No Liquibase changes — all required tables/columns already exist.
- No legacy endpoint deprecation, no changes to `supplies.partition_coefficient` or the Supply form.

## Test plan
- [x] Guard unit tests for both `canManageSharingAgreement` overloads (create + patch/delete/publish), covering unauthenticated, cross-community, cross-plant, non-admin, and admin cases.
- [x] Domain unit tests for `SharingAgreement.assertDraft()`.
- [x] Controller tests per endpoint covering 401 / 403 / 404 (cross-community and cross-plant-same-community) / happy path, plus 409 coverage for PATCH/DELETE/publish on non-DRAFT agreements and publish on a DRAFT agreement with zero coefficients.
- [x] `./gradlew build` — full build green, including all ArchUnit tests (`RepositoryTransactionalArchTest`, `ServiceTransactionalArchTest`, `AuthorizationLocationArchTest`, `ControllerRepositoryAccessArchTest`, `JpaUsageArchTest`) with no new exception-list entries required.
- [x] Direct unit tests for each *ServiceImpl (mocked collaborators) and integration tests for each *RepositoryDatabase (real DB via Testcontainers), covering all four verbs — not just indirectly through the controller tests.