### PR TITLE
[conluz-222] Stop persisting the inert partitionCoefficient scalar on Supply create/update

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/update/UpdateSupplyDto.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/update/UpdateSupplyDto.java
@@ -8,14 +8,12 @@ public class UpdateSupplyDto {
     private final String name;
     private final String address;
     private final String addressRef;
-    private final Float partitionCoefficient;
 
     private UpdateSupplyDto(Builder builder) {
         this.code = builder.code;
         this.name = builder.name;
         this.address = builder.address;
         this.addressRef = builder.addressRef;
-        this.partitionCoefficient = builder.partitionCoefficient;
     }
 
     public static class Builder {
@@ -23,7 +21,6 @@ public class UpdateSupplyDto {
         private String name;
         private String address;
         private String addressRef;
-        private Float partitionCoefficient;
 
         public Builder() {
         }
@@ -48,11 +45,6 @@ public class UpdateSupplyDto {
             return this;
         }
 
-        public Builder partitionCoefficient(Float partitionCoefficient) {
-            this.partitionCoefficient = partitionCoefficient;
-            return this;
-        }
-
         public UpdateSupplyDto build() {
             return new UpdateSupplyDto(this);
         }
@@ -74,10 +66,6 @@ public class UpdateSupplyDto {
         return addressRef;
     }
 
-    public Float getPartitionCoefficient() {
-        return partitionCoefficient;
-    }
-
     public Supply mapToSupply(Supply.Builder supplyBuilder) {
         supplyBuilder
                 .withCode(code)
@@ -85,9 +73,6 @@ public class UpdateSupplyDto {
                 .withAddressRef(addressRef);
         if (name != null) {
             supplyBuilder.withName(name);
-        }
-        if (partitionCoefficient != null) {
-            supplyBuilder.withPartitionCoefficient(partitionCoefficient);
         }
         return supplyBuilder.build();
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyResponse.java
@@ -23,7 +23,9 @@ public class SupplyResponse {
     private final String address;
     @Schema(description = "Reference ID of the address", example = "4ASDF654ASDF89ASD")
     private final String addressRef;
-    @Schema(description = "Address of the supply", example = "2.403561")
+    @Schema(description = "Legacy partition coefficient of the supply. No longer authoritative: " +
+            "the sharing-agreement coefficient timeline is the source of truth for production calculations.",
+            example = "2.403561")
     private final Float partitionCoefficient;
     @Schema(description = "Whether the supply is enabled or disabled", example = "true")
     private final Boolean enabled;

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSuppliesWithFileController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSuppliesWithFileController.java
@@ -111,7 +111,7 @@ public class CreateSuppliesWithFileController {
     @InternalServerErrorResponse
     @PreAuthorize("@communityAccessGuard.canManageCommunity(#communityId)")
     public ResponseEntity createSuppliesWithFile(
-            @Parameter(description = "CSV file format: code(String), address(String), partitionCoefficient(Float), address(String), personalId(String).")
+            @Parameter(description = "CSV file format: code(String), address(String), addressRef(String), personalId(String).")
             @RequestParam("file") MultipartFile file,
             @Parameter(description = "Target community UUID.")
             @RequestParam(value = "communityId", required = false) UUID communityId) {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSupplyBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSupplyBody.java
@@ -3,7 +3,6 @@ package org.lucoenergia.conluz.infrastructure.admin.supply.create;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.user.User;
 
@@ -22,8 +21,6 @@ public class CreateSupplyBody {
     private String address;
     @NotEmpty
     private String addressRef;
-    @PositiveOrZero
-    private Float partitionCoefficient;
     private String name;
     @NotNull
     private UUID communityId;
@@ -50,14 +47,6 @@ public class CreateSupplyBody {
 
     public void setAddressRef(String addressRef) {
         this.addressRef = addressRef;
-    }
-
-    public Float getPartitionCoefficient() {
-        return partitionCoefficient;
-    }
-
-    public void setPartitionCoefficient(Float partitionCoefficient) {
-        this.partitionCoefficient = partitionCoefficient;
     }
 
     public String getPersonalId() {
@@ -89,7 +78,6 @@ public class CreateSupplyBody {
         builder.withCode(code != null ? code.trim() : null)
                 .withAddress(address != null ? address.trim() : null)
                 .withAddressRef(addressRef != null ? addressRef.trim() : null)
-                .withPartitionCoefficient(partitionCoefficient != null ? partitionCoefficient : 0.0F)
                 .withUser(personalId != null ? new User.Builder().personalId(personalId.trim()).build() : null);
 
         if (name != null && !name.isBlank()) {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyBody.java
@@ -2,7 +2,6 @@ package org.lucoenergia.conluz.infrastructure.admin.supply.update;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Positive;
 import org.lucoenergia.conluz.domain.admin.supply.update.UpdateSupplyDto;
 
 
@@ -18,8 +17,6 @@ public class UpdateSupplyBody {
     private String address;
     @NotEmpty
     private String addressRef;
-    @Positive
-    private Float partitionCoefficient;
 
 
     public String getCode() {
@@ -54,21 +51,12 @@ public class UpdateSupplyBody {
         this.addressRef = addressRef;
     }
 
-    public Float getPartitionCoefficient() {
-        return partitionCoefficient;
-    }
-
-    public void setPartitionCoefficient(Float partitionCoefficient) {
-        this.partitionCoefficient = partitionCoefficient;
-    }
-
     public UpdateSupplyDto mapToSupply() {
         UpdateSupplyDto.Builder builder = new UpdateSupplyDto.Builder();
         builder.code(code)
                 .name(name)
                 .address(address)
-                .addressRef(addressRef)
-                .partitionCoefficient(partitionCoefficient);
+                .addressRef(addressRef);
         return builder.build();
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyRepositoryDatabase.java
@@ -40,7 +40,6 @@ public class UpdateSupplyRepositoryDatabase implements UpdateSupplyRepository {
         currentSupply.setName(supply.getName());
         currentSupply.setAddress(supply.getAddress());
         currentSupply.setAddressRef(supply.getAddressRef());
-        currentSupply.setPartitionCoefficient(supply.getPartitionCoefficient());
 
         if (supply.getContract() != null) {
             if (currentSupply.getContract() == null) {

--- a/src/test/java/org/lucoenergia/conluz/domain/admin/supply/update/UpdateSupplyDtoTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/admin/supply/update/UpdateSupplyDtoTest.java
@@ -15,7 +15,6 @@ class UpdateSupplyDtoTest {
                 .name("Supply Name")
                 .address("123 Main Street")
                 .addressRef("Ref123")
-                .partitionCoefficient(0.75f)
                 .build();
 
         Supply.Builder supplyBuilder = new Supply.Builder();
@@ -28,31 +27,6 @@ class UpdateSupplyDtoTest {
         assertEquals("Supply Name", supply.getName());
         assertEquals("123 Main Street", supply.getAddress());
         assertEquals("Ref123", supply.getAddressRef());
-        assertEquals(0.75f, supply.getPartitionCoefficient());
-    }
-
-    @Test
-    void testMapToSupply_withNullPartitionCoefficient_preservesExistingValue() {
-        // Arrange
-        UpdateSupplyDto updateSupplyDto = new UpdateSupplyDto.Builder()
-                .code("SUP124")
-                .name("Supply Name 2")
-                .address("456 Another Street")
-                .addressRef("Ref456")
-                .partitionCoefficient(null)
-                .build();
-
-        Supply.Builder supplyBuilder = new Supply.Builder().withPartitionCoefficient(0.5f);
-
-        // Act
-        Supply supply = updateSupplyDto.mapToSupply(supplyBuilder);
-
-        // Assert
-        assertEquals("SUP124", supply.getCode());
-        assertEquals("Supply Name 2", supply.getName());
-        assertEquals("456 Another Street", supply.getAddress());
-        assertEquals("Ref456", supply.getAddressRef());
-        assertEquals(0.5f, supply.getPartitionCoefficient());
     }
 
     @Test
@@ -62,7 +36,6 @@ class UpdateSupplyDtoTest {
                 .code("SUP126")
                 .address("789 Test Street")
                 .addressRef("Ref789")
-                .partitionCoefficient(0.3f)
                 .build();
 
         Supply.Builder supplyBuilder = new Supply.Builder().withName("Existing Name");
@@ -72,7 +45,6 @@ class UpdateSupplyDtoTest {
 
         // Assert
         assertEquals("Existing Name", supply.getName());
-        assertEquals(0.3f, supply.getPartitionCoefficient());
     }
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSupplyBodyTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSupplyBodyTest.java
@@ -15,7 +15,6 @@ class CreateSupplyBodyTest {
         body.setPersonalId(" PERSONAL456  ");
         body.setAddress(" Test Address  ");
         body.setAddressRef("ASDFKSDF98I78");
-        body.setPartitionCoefficient(1.2f);
         body.setName(" Supply Name ");
 
         // Perform mapping
@@ -27,7 +26,7 @@ class CreateSupplyBodyTest {
         assertEquals("PERSONAL456", result.getUser().getPersonalId());
         assertEquals("Test Address", result.getAddress());
         assertEquals(body.getAddressRef(), result.getAddressRef());
-        assertEquals(1.2f, result.getPartitionCoefficient());
+        assertEquals(0.0F, result.getPartitionCoefficient());
         assertEquals("Supply Name", result.getName());
     }
 
@@ -39,7 +38,6 @@ class CreateSupplyBodyTest {
         body.setPersonalId("PERSONAL456");
         body.setAddress("Test Address");
         body.setAddressRef("ASDFKSDF98I78");
-        body.setPartitionCoefficient(1.2f);
         body.setName(null);
 
         // Perform mapping
@@ -52,7 +50,7 @@ class CreateSupplyBodyTest {
         assertEquals("Test Address", result.getAddress());
         assertEquals(body.getAddressRef(), result.getAddressRef());
         assertEquals(body.getAddressRef(), result.getAddressRef());
-        assertEquals(1.2f, result.getPartitionCoefficient());
+        assertEquals(0.0F, result.getPartitionCoefficient());
         assertNull(result.getName());
     }
 
@@ -64,7 +62,6 @@ class CreateSupplyBodyTest {
         body.setPersonalId("PERSONAL456");
         body.setAddress("Test Address");
         body.setAddressRef("ASDFKSDF98I78");
-        body.setPartitionCoefficient(1.2f);
         body.setName("  ");
 
         // Perform mapping
@@ -76,7 +73,7 @@ class CreateSupplyBodyTest {
         assertEquals("PERSONAL456", result.getUser().getPersonalId());
         assertEquals("Test Address", result.getAddress());
         assertEquals(body.getAddressRef(), result.getAddressRef());
-        assertEquals(1.2f, result.getPartitionCoefficient());
+        assertEquals(0.0F, result.getPartitionCoefficient());
         assertNull(result.getName());
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSupplyControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/create/CreateSupplyControllerTest.java
@@ -58,8 +58,7 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                   "communityId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
                   "personalId": "%s",
                   "address": "Fake Street 123",
-                  "addressRef": "4ASDF654ASDF89ASD",
-                  "partitionCoefficient": "3.0763"
+                  "addressRef": "4ASDF654ASDF89ASD"
                 }
         """, userPersonalId);
 
@@ -73,7 +72,7 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.code").value("ES0033333333333333AA0A"))
                 .andExpect(jsonPath("$.address").value("Fake Street 123"))
                 .andExpect(jsonPath("$.addressRef").value("4ASDF654ASDF89ASD"))
-                .andExpect(jsonPath("$.partitionCoefficient").value("3.0763"))
+                .andExpect(jsonPath("$.partitionCoefficient").value(0.0))
                 .andExpect(jsonPath("$.name").isEmpty())
                 .andExpect(jsonPath("$.enabled").value(true))
                 .andExpect(jsonPath("$.user.id").value(user.getId().toString()))
@@ -105,7 +104,6 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                   "personalId": "%s",
                   "address": "Fake Street 456",
                   "addressRef": "4ASDF654ASDF89ASD",
-                  "partitionCoefficient": "2.5432",
                   "name": "Test Supply Name"
                 }
         """, userPersonalId);
@@ -120,7 +118,7 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.code").value("ES0033333333333333BB0B"))
                 .andExpect(jsonPath("$.address").value("Fake Street 456"))
                 .andExpect(jsonPath("$.addressRef").value("4ASDF654ASDF89ASD"))
-                .andExpect(jsonPath("$.partitionCoefficient").value("2.5432"))
+                .andExpect(jsonPath("$.partitionCoefficient").value(0.0))
                 .andExpect(jsonPath("$.name").value("Test Supply Name")) // Name is explicitly provided
                 .andExpect(jsonPath("$.enabled").value(true))
                 .andExpect(jsonPath("$.user.id").value(user.getId().toString()))
@@ -133,37 +131,6 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.user.enabled").value(user.isEnabled()));
 
         Assertions.assertEquals(1, supplyRepository.countByCode("ES0033333333333333BB0B"));
-    }
-
-    @Test
-    void testCreateSupplyWithoutPartitionCoefficient() throws Exception {
-
-        String authHeader = loginAsCommunityAdmin(DEFAULT_COMMUNITY_ID);
-
-        String userPersonalId = "54889216G";
-        User user = UserMother.randomUser();
-        user.setPersonalId(userPersonalId);
-        createUserRepository.create(user);
-
-        String body = String.format("""
-                {
-                  "code": "ES0033333333333333CC0C",
-                  "communityId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-                  "personalId": "%s",
-                  "address": "Fake Street 789",
-                  "addressRef": "4ASDF654ASDF89ASD"
-                }
-        """, userPersonalId);
-
-        mockMvc.perform(post(URL)
-                        .header(HttpHeaders.AUTHORIZATION, authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.partitionCoefficient").value(0.0));
-
-        Assertions.assertEquals(1, supplyRepository.countByCode("ES0033333333333333CC0C"));
     }
 
     @Test
@@ -182,11 +149,10 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                   "personalId": "%s",
                   "address": "%s",
                   "addressRef": "%s",
-                  "partitionCoefficient": "%s",
                   "communityId": "%s"
                 }
         """, supply.getCode(), user.getPersonalId(), supply.getAddress(), supply.getAddressRef(),
-                supply.getPartitionCoefficient(), DEFAULT_COMMUNITY_ID);
+                DEFAULT_COMMUNITY_ID);
 
         mockMvc.perform(post(URL)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
@@ -227,31 +193,27 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                         {
                           "personalId": "54889216G",
                           "address": "Fake Street 456",
-                          "addressRef": "4ASDF654ASDF89ASD",
-                          "partitionCoefficient": "2.5432"
+                          "addressRef": "4ASDF654ASDF89ASD"
                         }
                 """,
                 """
                         {
                           "code": "ES0033333333333333BB0B",
                           "address": "Fake Street 456",
-                          "addressRef": "4ASDF654ASDF89ASD",
-                          "partitionCoefficient": "2.5432"
+                          "addressRef": "4ASDF654ASDF89ASD"
                         }
                 """,
                 """
                         {
                           "code": "ES0033333333333333BB0B",
                           "personalId": "54889216G",
-                          "addressRef": "4ASDF654ASDF89ASD",
-                          "partitionCoefficient": "2.5432"
+                          "addressRef": "4ASDF654ASDF89ASD"
                         }
                 """,
                 """
                         {
                           "code": "ES0033333333333333BB0B",
                           "personalId": "54889216G",
-                          "partitionCoefficient": "2.5432",
                           "address": "Fake Street 456"
                         }
                 """,
@@ -261,8 +223,7 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                           "code": "ES0033333333333333BB0B",
                           "personalId": "54889216G",
                           "address": "Fake Street 456",
-                          "addressRef": "4ASDF654ASDF89ASD",
-                          "partitionCoefficient": "2.5432"
+                          "addressRef": "4ASDF654ASDF89ASD"
                         }
                 """
                 );
@@ -285,8 +246,7 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                   "communityId": "%s",
                   "personalId": "%s",
                   "address": "Fake Street 123",
-                  "addressRef": "4ASDF654ASDF89ASD",
-                  "partitionCoefficient": "3.0763"
+                  "addressRef": "4ASDF654ASDF89ASD"
                 }
         """, java.util.UUID.randomUUID(), userPersonalId);
 
@@ -297,54 +257,6 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getBodyWithInvalidFormatValues")
-    void testWithInvalidFormatValues(String body) throws Exception {
-
-        String authHeader = loginAsCommunityAdmin(DEFAULT_COMMUNITY_ID);
-
-        mockMvc.perform(post(URL)
-                        .header(HttpHeaders.AUTHORIZATION, authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.timestamp").isNotEmpty())
-                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                .andExpect(jsonPath("$.message").isNotEmpty())
-                .andExpect(jsonPath("$.traceId").isNotEmpty());
-    }
-
-    static List<String> getBodyWithInvalidFormatValues() {
-        return List.of("""
-                    {
-                      "code": "ES0033333333333333AA0A",
-                      "personalId": "54889216G",
-                      "address": "Fake Street 123",
-                      "addressRef": "4ASDF654ASDF89ASD",
-                      "partitionCoefficient": "-3.0763"
-                    }
-                """,
-                """
-                    {
-                      "code": "ES0033333333333333AA0A",
-                      "personalId": "54889216G",
-                      "address": "Fake Street 123",
-                      "addressRef": "4ASDF654ASDF89ASD",
-                      "partitionCoefficient": "3,0763"
-                    }
-                """,
-                """
-                    {
-                      "code": "ES0033333333333333AA0A",
-                      "personalId": "54889216G",
-                      "address": "Fake Street 123",
-                      "addressRef": "4ASDF654ASDF89ASD",
-                      "partitionCoefficient": "foo"
-                    }
-                """);
     }
 
     @Test
@@ -387,8 +299,7 @@ class CreateSupplyControllerTest extends BaseControllerTest {
                   "communityId": "%s",
                   "personalId": "%s",
                   "address": "Fake Street 123",
-                  "addressRef": "4ASDF654ASDF89ASD",
-                  "partitionCoefficient": "3.0763"
+                  "addressRef": "4ASDF654ASDF89ASD"
                 }
         """, DEFAULT_COMMUNITY_ID, userPersonalId);
 

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyBodyTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyBodyTest.java
@@ -15,7 +15,6 @@ class UpdateSupplyBodyTest {
         updateSupplyBody.setName("name");
         updateSupplyBody.setAddress("address");
         updateSupplyBody.setAddressRef("addressRef");
-        updateSupplyBody.setPartitionCoefficient(0.5f);
 
         // Act
         UpdateSupplyDto supply = updateSupplyBody.mapToSupply();
@@ -25,6 +24,5 @@ class UpdateSupplyBodyTest {
         assertEquals("name", supply.getName());
         assertEquals("address", supply.getAddress());
         assertEquals("addressRef", supply.getAddressRef());
-        assertEquals(0.5f, supply.getPartitionCoefficient());
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyControllerTest.java
@@ -59,7 +59,6 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
         supplyModified.setName("name");
         supplyModified.setAddress("address");
         supplyModified.setAddressRef("4ASDF654ASDF89ASD");
-        supplyModified.setPartitionCoefficient(1.2f);
 
         String bodyAsString = objectMapper.writeValueAsString(supplyModified);
 
@@ -73,7 +72,7 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.name").value(supplyModified.getName()))
                 .andExpect(jsonPath("$.address").value(supplyModified.getAddress()))
                 .andExpect(jsonPath("$.addressRef").value(supplyModified.getAddressRef()))
-                .andExpect(jsonPath("$.partitionCoefficient").value(supplyModified.getPartitionCoefficient()))
+                .andExpect(jsonPath("$.partitionCoefficient").value(supply.getPartitionCoefficient()))
                 .andExpect(jsonPath("$.enabled").value(supply.getEnabled()))
                 .andExpect(jsonPath("$.contract.validDateFrom").value(supply.getContract().getValidDateFrom().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
                 .andExpect(jsonPath("$.distributor.name").value(supply.getDistributor().getName()))
@@ -97,8 +96,7 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                           "code": "code",
                           "name": "my home",
                           "address": "Fake Street 123",
-                          "addressRef": "4ASDF654ASDF89ASD",
-                          "partitionCoefficient": 1.2
+                          "addressRef": "4ASDF654ASDF89ASD"
                         }
                 """;
 
@@ -122,8 +120,7 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                           "unknown": 1,
                           "code": "code",
                           "address": "Fake Street 123",
-                          "addressRef": "4ASDF654ASDF89ASD",
-                          "partitionCoefficient": 1.2
+                          "addressRef": "4ASDF654ASDF89ASD"
                         }
                 """;
 
@@ -168,15 +165,13 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                 """
                                 {
                                   "address": "Fake Street 123",
-                                  "addressRef": "4ASDF654ASDF89ASD",
-                                  "partitionCoefficient": 1.2
+                                  "addressRef": "4ASDF654ASDF89ASD"
                                 }
                         """,
                 """
                                 {
                                   "code": "code",
-                                  "addressRef": "4ASDF654ASDF89ASD",
-                                  "partitionCoefficient": 1.2
+                                  "addressRef": "4ASDF654ASDF89ASD"
                                 }
                         """,
                 """
@@ -189,8 +184,7 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                 """
                                 {
                                   "code": "code",
-                                  "address": "Fake Street 123",
-                                  "partitionCoefficient": 1.2
+                                  "address": "Fake Street 123"
                                 }
                         """);
     }
@@ -221,7 +215,6 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                                  "code": "ES0031300326337001WS0F",
                                  "address": "MAYOR 1",
                                  "addressRef": "4ASDF654ASDF89ASD",
-                                 "partitionCoefficient": 0.021255,
                                  "personalId": "personalId",
                                  "enabled": true,
                                  "validDateFrom": "2023-05-01"
@@ -232,7 +225,6 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                                  "code": "ES0031300326337001WS0F",
                                  "address": "MAYOR 1",
                                  "addressRef": "4ASDF654ASDF89ASD",
-                                 "partitionCoefficient": 0.021255,
                                  "personalId": "personalId",
                                  "enabled": true,
                                  "pointType": "foo"
@@ -243,7 +235,6 @@ class UpdateSupplyControllerTest extends BaseControllerTest {
                                  "code": "ES0031300326337001WS0F",
                                  "address": "MAYOR 1",
                                  "addressRef": "4ASDF654ASDF89ASD",
-                                 "partitionCoefficient": 0.021255,
                                  "personalId": "personalId",
                                  "enabled": "foo"
                              }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyServiceTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyServiceTest.java
@@ -42,7 +42,6 @@ class UpdateSupplyServiceTest {
                 .code("NEWCODE123")
                 .name("Updated Supply")
                 .address("456 Avenue")
-                .partitionCoefficient(2.0f)
                 .build();
 
         Supply updatedSupply = new Supply.Builder()
@@ -79,7 +78,6 @@ class UpdateSupplyServiceTest {
                 .code("NEWCODE123")
                 .name("Updated Supply")
                 .address("456 Avenue")
-                .partitionCoefficient(2.0f)
                 .build();
 
         when(getSupplyRepository.findById(supplyId)).thenReturn(Optional.empty());


### PR DESCRIPTION
Summary                                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  - supplies.partition_coefficient has been computationally dead since phase 4 (no production calculation reads it — the sharing-agreement coefficient timeline is authoritative) and phase 5d removed the timeline→scalar 
  sync. It was still accepted and persisted on Supply create/update, which is worse than a frozen value: an admin edits it, the request succeeds, the number is stored, and nothing downstream ever reads it again. This   
  removes that illusion of control on the write path.                                                                                                                                                                      
  - CreateSupplyBody, UpdateSupplyBody, and UpdateSupplyDto no longer accept partitionCoefficient; new supplies persist the domain default (0.0F), and updates leave the existing column value untouched (the now-pointless
  self-assignment in UpdateSupplyRepositoryDatabase is removed).                                                                                                                                                           
  - SupplyResponse still returns the field — the DB column isn't dropped until phase 6 — but its @Schema description is corrected (it previously read "Address of the supply", a copy-paste bug) and now states it's       
  legacy/non-authoritative.                                                                                                                                                                                                
  - CreateSuppliesWithFileController's bulk CSV-import Swagger doc updated to match; verified the existing CSV fixture (which still has a partitionCoefficient column) still imports cleanly — OpenCSV's header-based      
  binding silently ignores the now-unmapped column rather than erroring.                                                                                                                                                   
                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                           
  Test plan                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  - [x] ./gradlew build — full build, test suite, and ArchUnit checks pass clean                                                                                                                                           
  - [x] CreateSupplyControllerTest, UpdateSupplyControllerTest, and DTO/service unit tests updated: removed assertions on the deleted field, deleted tests whose premise no longer exists (numeric-format validation on the
  removed field, null-preserves-existing-value), and stripped partitionCoefficient from JSON body fixtures — including in 404-path tests that would otherwise start getting a 400 instead                                  
  - [x] CreateSuppliesWithFileControllerTest (bulk CSV import) — 10/10 pass, confirming an old-format CSV with the now-unmapped column still imports successfully                                                          
  - [x] Manual: POST /api/v1/supplies and PUT /api/v1/supplies/{id} without partitionCoefficient in the body still return 200/201 with the response's partitionCoefficient reflecting the new default/unchanged value