### PR TITLE
[conluz-234] Unify REST URL path parameters to the {resourceId} naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ deploy/local/snapshots/
 deploy/deploy-local-restore-*.dump
 
 .junie
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,12 @@ With the app running:
 - Follow SOLID and Clean Code principles
 - Code and comments must be in English
 - Code should be self-explanatory with comments when additional explanation is needed
+- **URL path parameter naming**: All REST API URL path segments that identify a resource MUST use the
+  `{resourceId}` convention (e.g. `{supplyId}`, `{userId}`, `{plantId}`, `{communityId}`,
+  `{sharingAgreementId}`). The bare `{id}` pattern is never used. The same name MUST be used
+  consistently for the `@PathVariable` annotation value and the Java method parameter name. This
+  ensures OpenAPI specs are self-documenting and eliminates ambiguity when multiple IDs appear in
+  the same URL.
 - All new code must have automated tests
 - Architecture tests are enforced via ArchUnit (see `src/test/java/org/lucoenergia/conluz/architecture/`)
 - When injecting beans, always use the interface. This also applies to integration tests

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/get/GetCommunityByIdController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/get/GetCommunityByIdController.java
@@ -35,7 +35,7 @@ public class GetCommunityByIdController {
         this.service = service;
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{communityId}")
     @Operation(
             summary = "Retrieves a community by its ID.",
             description = """
@@ -60,9 +60,9 @@ public class GetCommunityByIdController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("isAuthenticated() and @communityAccessGuard.canReadCommunity(#id)")
-    public ResponseEntity<CommunityResponse> getCommunityById(@PathVariable("id") UUID id) {
-        return service.findByIdWithStats(id)
+    @PreAuthorize("isAuthenticated() and @communityAccessGuard.canReadCommunity(#communityId)")
+    public ResponseEntity<CommunityResponse> getCommunityById(@PathVariable("communityId") UUID communityId) {
+        return service.findByIdWithStats(communityId)
                 .map(c -> ResponseEntity.ok(new CommunityResponse(c)))
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/CreateMembershipController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/CreateMembershipController.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/communities/{id}/memberships",
+        value = "/api/v1/communities/{communityId}/memberships",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -60,10 +60,10 @@ public class CreateMembershipController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageMemberships(#id)")
-    public MembershipResponse createMembership(@PathVariable("id") UUID id,
+    @PreAuthorize("@communityAccessGuard.canManageMemberships(#communityId)")
+    public MembershipResponse createMembership(@PathVariable("communityId") UUID communityId,
                                                 @Valid @RequestBody CreateMembershipBody body) {
-        CommunityMembership membership = service.create(id, body.getUserId(), body.getRole());
+        CommunityMembership membership = service.create(communityId, body.getUserId(), body.getRole());
         return new MembershipResponse(membership);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/DeleteMembershipController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/DeleteMembershipController.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/communities/{id}/memberships",
+        value = "/api/v1/communities/{communityId}/memberships",
         produces = MediaType.APPLICATION_JSON_VALUE
 )
 public class DeleteMembershipController {
@@ -53,9 +53,9 @@ public class DeleteMembershipController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageMemberships(#id)")
-    public void deleteMembership(@PathVariable("id") UUID id,
+    @PreAuthorize("@communityAccessGuard.canManageMemberships(#communityId)")
+    public void deleteMembership(@PathVariable("communityId") UUID communityId,
                                   @PathVariable("userId") UUID userId) {
-        service.delete(id, userId);
+        service.delete(communityId, userId);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/GetMembershipsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/GetMembershipsController.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/communities/{id}/memberships",
+        value = "/api/v1/communities/{communityId}/memberships",
         produces = MediaType.APPLICATION_JSON_VALUE
 )
 public class GetMembershipsController {
@@ -55,9 +55,9 @@ public class GetMembershipsController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageMemberships(#id)")
-    public List<MembershipResponse> getMemberships(@PathVariable("id") UUID id) {
-        List<CommunityMembership> memberships = service.findByCommunityId(id);
+    @PreAuthorize("@communityAccessGuard.canManageMemberships(#communityId)")
+    public List<MembershipResponse> getMemberships(@PathVariable("communityId") UUID communityId) {
+        List<CommunityMembership> memberships = service.findByCommunityId(communityId);
         return memberships.stream()
                 .map(MembershipResponse::new)
                 .toList();

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/UpdateMembershipRoleController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/membership/UpdateMembershipRoleController.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/communities/{id}/memberships",
+        value = "/api/v1/communities/{communityId}/memberships",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -57,11 +57,11 @@ public class UpdateMembershipRoleController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageMemberships(#id)")
-    public MembershipResponse updateMembershipRole(@PathVariable("id") UUID id,
+    @PreAuthorize("@communityAccessGuard.canManageMemberships(#communityId)")
+    public MembershipResponse updateMembershipRole(@PathVariable("communityId") UUID communityId,
                                                     @PathVariable("userId") UUID userId,
                                                     @Valid @RequestBody UpdateMembershipRoleBody body) {
-        CommunityMembership membership = service.updateRole(id, userId, body.getRole());
+        CommunityMembership membership = service.updateRole(communityId, userId, body.getRole());
         return new MembershipResponse(membership);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/state/DisableCommunityController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/state/DisableCommunityController.java
@@ -32,7 +32,7 @@ public class DisableCommunityController {
         this.stateService = stateService;
     }
 
-    @PostMapping("/{id}/disable")
+    @PostMapping("/{communityId}/disable")
     @Operation(
             summary = "Disables a community.",
             description = "Disables an existing community. Requires PLATFORM_ADMIN role.",
@@ -53,7 +53,7 @@ public class DisableCommunityController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("hasRole('PLATFORM_ADMIN')")
-    public void disableCommunity(@PathVariable("id") UUID id) {
-        stateService.disable(id);
+    public void disableCommunity(@PathVariable("communityId") UUID communityId) {
+        stateService.disable(communityId);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/state/EnableCommunityController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/state/EnableCommunityController.java
@@ -32,7 +32,7 @@ public class EnableCommunityController {
         this.stateService = stateService;
     }
 
-    @PostMapping("/{id}/enable")
+    @PostMapping("/{communityId}/enable")
     @Operation(
             summary = "Enables a community.",
             description = "Re-enables a previously disabled community. Requires PLATFORM_ADMIN role.",
@@ -53,7 +53,7 @@ public class EnableCommunityController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("hasRole('PLATFORM_ADMIN')")
-    public void enableCommunity(@PathVariable("id") UUID id) {
-        stateService.enable(id);
+    public void enableCommunity(@PathVariable("communityId") UUID communityId) {
+        stateService.enable(communityId);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/update/UpdateCommunityController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/community/update/UpdateCommunityController.java
@@ -38,7 +38,7 @@ public class UpdateCommunityController {
         this.service = service;
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/{communityId}")
     @Operation(
             summary = "Updates an existing community.",
             description = """
@@ -62,9 +62,9 @@ public class UpdateCommunityController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("hasRole('PLATFORM_ADMIN')")
-    public CommunityResponse updateCommunity(@PathVariable("id") UUID id,
+    public CommunityResponse updateCommunity(@PathVariable("communityId") UUID communityId,
                                               @Valid @RequestBody UpdateCommunityBody body) {
-        Community community = service.update(id, body.mapToCommunity());
+        Community community = service.update(communityId, body.mapToCommunity());
         return new CommunityResponse(community);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyDailyConsumptionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyDailyConsumptionController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * Controller for retrieving daily consumption data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/consumption/daily")
+@RequestMapping("/api/v1/supplies/{supplyId}/consumption/daily")
 public class GetSupplyDailyConsumptionController {
 
     private final GetDatadisConsumptionService getDatadisConsumptionService;
@@ -72,12 +72,12 @@ public class GetSupplyDailyConsumptionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<DatadisConsumption> getSupplyDailyConsumption(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getDatadisConsumptionService.getDailyConsumptionBySupply(SupplyId.of(id), startDate, endDate);
+        return getDatadisConsumptionService.getDailyConsumptionBySupply(SupplyId.of(supplyId), startDate, endDate);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyHourlyConsumptionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyHourlyConsumptionController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * Controller for retrieving hourly consumption data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/consumption/hourly")
+@RequestMapping("/api/v1/supplies/{supplyId}/consumption/hourly")
 public class GetSupplyHourlyConsumptionController {
 
     private final GetDatadisConsumptionService getDatadisConsumptionService;
@@ -72,12 +72,12 @@ public class GetSupplyHourlyConsumptionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<DatadisConsumption> getSupplyHourlyConsumption(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getDatadisConsumptionService.getHourlyConsumptionBySupply(SupplyId.of(id), startDate, endDate);
+        return getDatadisConsumptionService.getHourlyConsumptionBySupply(SupplyId.of(supplyId), startDate, endDate);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyMonthlyConsumptionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyMonthlyConsumptionController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * Controller for retrieving monthly consumption data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/consumption/monthly")
+@RequestMapping("/api/v1/supplies/{supplyId}/consumption/monthly")
 public class GetSupplyMonthlyConsumptionController {
 
     private final GetDatadisConsumptionService getDatadisConsumptionService;
@@ -72,12 +72,12 @@ public class GetSupplyMonthlyConsumptionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<DatadisConsumption> getSupplyMonthlyConsumption(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getDatadisConsumptionService.getMonthlyConsumptionBySupply(SupplyId.of(id), startDate, endDate);
+        return getDatadisConsumptionService.getMonthlyConsumptionBySupply(SupplyId.of(supplyId), startDate, endDate);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyYearlyConsumptionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/consumption/GetSupplyYearlyConsumptionController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * Controller for retrieving yearly consumption data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/consumption/yearly")
+@RequestMapping("/api/v1/supplies/{supplyId}/consumption/yearly")
 public class GetSupplyYearlyConsumptionController {
 
     private final GetDatadisConsumptionService getDatadisConsumptionService;
@@ -72,12 +72,12 @@ public class GetSupplyYearlyConsumptionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<DatadisConsumption> getSupplyYearlyConsumption(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getDatadisConsumptionService.getYearlyConsumptionBySupply(SupplyId.of(id), startDate, endDate);
+        return getDatadisConsumptionService.getYearlyConsumptionBySupply(SupplyId.of(supplyId), startDate, endDate);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/disable/DisableSupplyController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/disable/DisableSupplyController.java
@@ -28,7 +28,7 @@ public class DisableSupplyController {
         this.service = service;
     }
 
-    @PostMapping(path = "/supplies/{id}/disable")
+    @PostMapping(path = "/supplies/{supplyId}/disable")
     @Operation(
             summary = "Disables a supply by ID",
             description = """
@@ -56,7 +56,7 @@ public class DisableSupplyController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditSupply(#supplyId)")
-    public SupplyResponse disableSupply(@PathVariable("id") UUID supplyId) {
+    public SupplyResponse disableSupply(@PathVariable("supplyId") UUID supplyId) {
         Supply updated = service.disable(SupplyId.of(supplyId));
         return new SupplyResponse(updated);
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/enable/EnableSupplyController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/enable/EnableSupplyController.java
@@ -28,7 +28,7 @@ public class EnableSupplyController {
         this.service = service;
     }
 
-    @PostMapping(path = "/supplies/{id}/enable")
+    @PostMapping(path = "/supplies/{supplyId}/enable")
     @Operation(
             summary = "Enables a supply by ID",
             description = """
@@ -56,7 +56,7 @@ public class EnableSupplyController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditSupply(#supplyId)")
-    public SupplyResponse enableSupply(@PathVariable("id") UUID supplyId) {
+    public SupplyResponse enableSupply(@PathVariable("supplyId") UUID supplyId) {
         Supply updated = service.enable(SupplyId.of(supplyId));
         return new SupplyResponse(updated);
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyByIdController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyByIdController.java
@@ -30,7 +30,7 @@ public class GetSupplyByIdController {
         this.service = service;
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{supplyId}")
     @Operation(
             summary = "Gets a supply by ID",
             description = """
@@ -52,9 +52,9 @@ public class GetSupplyByIdController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
-    public SupplyResponse getSupply(@PathVariable("id") UUID id) {
-        Supply supply = service.getById(SupplyId.of(id));
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
+    public SupplyResponse getSupply(@PathVariable("supplyId") UUID supplyId) {
+        Supply supply = service.getById(SupplyId.of(supplyId));
         return new SupplyResponse(supply);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyDailyProductionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyDailyProductionController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
  * Controller for retrieving daily production data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/production/daily")
+@RequestMapping("/api/v1/supplies/{supplyId}/production/daily")
 public class GetSupplyDailyProductionController {
 
     private final GetProductionService getProductionService;
@@ -56,12 +56,12 @@ public class GetSupplyDailyProductionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<ProductionByTime> getSupplyDailyProduction(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getProductionService.getDailyProductionByRangeOfDatesAndSupply(startDate, endDate, SupplyId.of(id));
+        return getProductionService.getDailyProductionByRangeOfDatesAndSupply(startDate, endDate, SupplyId.of(supplyId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyHourlyProductionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyHourlyProductionController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
  * Controller for retrieving hourly production data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/production/hourly")
+@RequestMapping("/api/v1/supplies/{supplyId}/production/hourly")
 public class GetSupplyHourlyProductionController {
 
     private final GetProductionService getProductionService;
@@ -56,12 +56,12 @@ public class GetSupplyHourlyProductionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<ProductionByTime> getSupplyHourlyProduction(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getProductionService.getHourlyProductionByRangeOfDatesAndSupply(startDate, endDate, SupplyId.of(id));
+        return getProductionService.getHourlyProductionByRangeOfDatesAndSupply(startDate, endDate, SupplyId.of(supplyId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyMonthlyProductionController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/production/GetSupplyMonthlyProductionController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
  * Controller for retrieving monthly production data for a specific supply
  */
 @RestController
-@RequestMapping("/api/v1/supplies/{id}/production/monthly")
+@RequestMapping("/api/v1/supplies/{supplyId}/production/monthly")
 public class GetSupplyMonthlyProductionController {
 
     private final GetProductionService getProductionService;
@@ -56,12 +56,12 @@ public class GetSupplyMonthlyProductionController {
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSupply(#id)")
+    @PreAuthorize("@communityAccessGuard.canReadSupply(#supplyId)")
     public List<ProductionByTime> getSupplyMonthlyProduction(
-            @PathVariable("id") UUID id,
+            @PathVariable("supplyId") UUID supplyId,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime endDate) {
 
-        return getProductionService.getMonthlyProductionByRangeOfDatesAndSupply(startDate, endDate, SupplyId.of(id));
+        return getProductionService.getMonthlyProductionByRangeOfDatesAndSupply(startDate, endDate, SupplyId.of(supplyId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/update/UpdateSupplyController.java
@@ -29,7 +29,7 @@ public class UpdateSupplyController {
         this.service = service;
     }
 
-    @PutMapping("/supplies/{id}")
+    @PutMapping("/supplies/{supplyId}")
     @Operation(
             summary = "Updates supply information",
             description = """
@@ -57,7 +57,7 @@ public class UpdateSupplyController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditSupply(#supplyId)")
-    public SupplyResponse updateSupply(@PathVariable("id") UUID supplyId, @Valid @RequestBody UpdateSupplyBody body) {
+    public SupplyResponse updateSupply(@PathVariable("supplyId") UUID supplyId, @Valid @RequestBody UpdateSupplyBody body) {
         return new SupplyResponse(service.update(SupplyId.of(supplyId), body.mapToSupply()));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/delete/DeleteUserController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/delete/DeleteUserController.java
@@ -26,7 +26,7 @@ public class DeleteUserController {
         this.service = service;
     }
 
-    @DeleteMapping("/users/{id}")
+    @DeleteMapping("/users/{userId}")
     @Operation(
             summary = "Removes a user by ID",
             description = """
@@ -55,7 +55,7 @@ public class DeleteUserController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditUser(#userId) and !@communityAccessGuard.isCurrentUser(#userId)")
-    public void deleteUser(@PathVariable("id") UUID userId) {
+    public void deleteUser(@PathVariable("userId") UUID userId) {
         service.delete(UserId.of(userId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/disable/DisableUserController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/disable/DisableUserController.java
@@ -29,7 +29,7 @@ public class DisableUserController {
         this.service = service;
     }
 
-    @PostMapping(path = "/users/{id}/disable")
+    @PostMapping(path = "/users/{userId}/disable")
     @Operation(
             summary = "Disables a user by ID",
             description = """
@@ -59,7 +59,7 @@ public class DisableUserController {
     @BadRequestErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditUser(#userId) and !@communityAccessGuard.isCurrentUser(#userId)")
-    public void disableUser(@PathVariable("id") UUID userId) {
+    public void disableUser(@PathVariable("userId") UUID userId) {
         service.disable(UserId.of(userId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/enable/EnableUserController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/enable/EnableUserController.java
@@ -29,7 +29,7 @@ public class EnableUserController {
         this.service = service;
     }
 
-    @PostMapping(path = "/users/{id}/enable")
+    @PostMapping(path = "/users/{userId}/enable")
     @Operation(
             summary = "Enables a user by ID",
             description = """
@@ -58,7 +58,7 @@ public class EnableUserController {
     @BadRequestErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditUser(#userId) and !@communityAccessGuard.isCurrentUser(#userId)")
-    public void enableUser(@PathVariable("id") UUID userId) {
+    public void enableUser(@PathVariable("userId") UUID userId) {
         service.enable(UserId.of(userId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/get/GetSuppliesByUserIdController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/get/GetSuppliesByUserIdController.java
@@ -36,7 +36,7 @@ public class GetSuppliesByUserIdController {
         this.supplyService = supplyService;
     }
 
-    @GetMapping("/{id}/supplies")
+    @GetMapping("/{userId}/supplies")
     @Operation(
             summary = "Retrieves all supplies for a specific user",
             description = """
@@ -65,7 +65,7 @@ public class GetSuppliesByUserIdController {
     @NotFoundErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("@communityAccessGuard.canReadUser(#userId)")
-    public List<SupplyResponse> getSuppliesByUserId(@PathVariable("id") UUID userId) {
+    public List<SupplyResponse> getSuppliesByUserId(@PathVariable("userId") UUID userId) {
         List<Supply> supplies = supplyService.getByUserId(UserId.of(userId));
 
         return supplies.stream()

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/get/GetUserByIdController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/get/GetUserByIdController.java
@@ -35,7 +35,7 @@ public class GetUserByIdController {
         this.service = service;
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{userId}")
     @Operation(
             summary = "Retrieves a single user by ID",
             description = """
@@ -62,7 +62,7 @@ public class GetUserByIdController {
     @NotFoundErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("@communityAccessGuard.canReadUser(#userId)")
-    public UserResponse getUserById(@PathVariable("id") UUID userId) {
+    public UserResponse getUserById(@PathVariable("userId") UUID userId) {
         User user = service.findById(UserId.of(userId));
         return new UserResponse(user);
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/GrantPlatformAdminController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/GrantPlatformAdminController.java
@@ -30,7 +30,7 @@ public class GrantPlatformAdminController {
         this.service = service;
     }
 
-    @PostMapping(path = "/users/{id}/grant-platform-admin")
+    @PostMapping(path = "/users/{userId}/grant-platform-admin")
     @Operation(
             summary = "Grants platform-admin privileges to a user by ID",
             description = """
@@ -60,7 +60,7 @@ public class GrantPlatformAdminController {
     @NotFoundErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("hasRole('PLATFORM_ADMIN')")
-    public void grantPlatformAdmin(@PathVariable("id") UUID userId) {
+    public void grantPlatformAdmin(@PathVariable("userId") UUID userId) {
         service.grant(UserId.of(userId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/RevokePlatformAdminController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/platformadmin/RevokePlatformAdminController.java
@@ -35,7 +35,7 @@ public class RevokePlatformAdminController {
         this.service = service;
     }
 
-    @PostMapping(path = "/users/{id}/revoke-platform-admin")
+    @PostMapping(path = "/users/{userId}/revoke-platform-admin")
     @Operation(
             summary = "Revokes platform-admin privileges from a user by ID",
             description = """
@@ -90,7 +90,7 @@ public class RevokePlatformAdminController {
     @NotFoundErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("hasRole('PLATFORM_ADMIN') and !@communityAccessGuard.isCurrentUser(#userId)")
-    public void revokePlatformAdmin(@PathVariable("id") UUID userId) {
+    public void revokePlatformAdmin(@PathVariable("userId") UUID userId) {
         service.revoke(UserId.of(userId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/update/UpdateUserController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/user/update/UpdateUserController.java
@@ -29,7 +29,7 @@ public class UpdateUserController {
         this.service = service;
     }
 
-    @PutMapping("/users/{id}")
+    @PutMapping("/users/{userId}")
     @Operation(
             summary = "Updates user information",
             description = """
@@ -58,7 +58,7 @@ public class UpdateUserController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canEditUser(#userId)")
-    public UserResponse updateUser(@PathVariable("id") UUID userId, @Valid @RequestBody UpdateUserBody body) {
+    public UserResponse updateUser(@PathVariable("userId") UUID userId, @Valid @RequestBody UpdateUserBody body) {
         return new UserResponse(service.update(body.toUser(userId)));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeletePlantController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/delete/DeletePlantController.java
@@ -26,7 +26,7 @@ public class DeletePlantController {
         this.service = service;
     }
 
-    @DeleteMapping("/plants/{id}")
+    @DeleteMapping("/plants/{plantId}")
     @Operation(
             summary = "Removes a plant by ID",
             description = """
@@ -60,7 +60,7 @@ public class DeletePlantController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canManagePlant(#plantId)")
-    public void deletePlant(@PathVariable("id") UUID plantId) {
+    public void deletePlant(@PathVariable("plantId") UUID plantId) {
         service.delete(PlantId.of(plantId));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantByIdController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/get/GetPlantByIdController.java
@@ -35,7 +35,7 @@ public class GetPlantByIdController {
         this.service = service;
     }
 
-    @GetMapping("/plants/{id}")
+    @GetMapping("/plants/{plantId}")
     @Operation(
             summary = "Retrieves a single plant by ID",
             description = """
@@ -65,7 +65,7 @@ public class GetPlantByIdController {
     @NotFoundErrorResponse
     @InternalServerErrorResponse
     @PreAuthorize("@communityAccessGuard.canReadPlant(#plantId)")
-    public PlantResponse getPlantById(@PathVariable("id") UUID plantId) {
+    public PlantResponse getPlantById(@PathVariable("plantId") UUID plantId) {
         Plant plant = service.findById(PlantId.of(plantId));
         return new PlantResponse(plant);
     }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/plant/update/UpdatePlantController.java
@@ -29,7 +29,7 @@ public class UpdatePlantController {
         this.service = service;
     }
 
-    @PutMapping("/plants/{id}")
+    @PutMapping("/plants/{plantId}")
     @Operation(
             summary = "Updates plant information",
             description = """
@@ -63,7 +63,7 @@ public class UpdatePlantController {
     @InternalServerErrorResponse
     @NotFoundErrorResponse
     @PreAuthorize("@communityAccessGuard.canManagePlant(#plantId)")
-    public PlantResponse updatePlant(@PathVariable("id") UUID plantId, @Valid @RequestBody UpdatePlantBody body) {
+    public PlantResponse updatePlant(@PathVariable("plantId") UUID plantId, @Valid @RequestBody UpdatePlantBody body) {
         return new PlantResponse(service.update(body.toPlant(plantId)));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/ReplacePartitionCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/ReplacePartitionCoefficientsController.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/partition-coefficients",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -82,12 +82,12 @@ public class ReplacePartitionCoefficientsController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
     public ReplacePartitionCoefficientsResponse replacePartitionCoefficients(
             @PathVariable UUID plantId,
-            @PathVariable UUID id,
+            @PathVariable UUID sharingAgreementId,
             @Valid @RequestBody ReplacePartitionCoefficientsBody body) {
-        List<SupplyPartitionCoefficient> saved = service.replaceAll(plantId, id, body.mapToEntries());
+        List<SupplyPartitionCoefficient> saved = service.replaceAll(plantId, sharingAgreementId, body.mapToEntries());
         return new ReplacePartitionCoefficientsResponse(saved);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/activation/ActivateCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/activation/ActivateCoefficientsController.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/partition-coefficients/activate",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients/activate",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -91,12 +91,12 @@ public class ActivateCoefficientsController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
     public CoefficientActivationResponse activateCoefficients(
             @PathVariable UUID plantId,
-            @PathVariable UUID id,
+            @PathVariable UUID sharingAgreementId,
             @Valid @RequestBody ActivateCoefficientsBody body) {
-        List<SupplyPartitionCoefficient> touched = service.setValidFrom(plantId, id, body.getAppliedOn(), body.getCoefficientIds());
+        List<SupplyPartitionCoefficient> touched = service.setValidFrom(plantId, sharingAgreementId, body.getAppliedOn(), body.getCoefficientIds());
         return new CoefficientActivationResponse(touched);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/close/CloseCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/close/CloseCoefficientsController.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/partition-coefficients/close",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients/close",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -89,12 +89,12 @@ public class CloseCoefficientsController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
     public CoefficientActivationResponse closeCoefficients(
             @PathVariable UUID plantId,
-            @PathVariable UUID id,
+            @PathVariable UUID sharingAgreementId,
             @Valid @RequestBody CloseCoefficientsBody body) {
-        List<SupplyPartitionCoefficient> touched = service.setValidTo(plantId, id, body.getClosedOn(), body.getCoefficientIds());
+        List<SupplyPartitionCoefficient> touched = service.setValidTo(plantId, sharingAgreementId, body.getClosedOn(), body.getCoefficientIds());
         return new CoefficientActivationResponse(touched);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/deactivate/DeactivateCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/deactivate/DeactivateCoefficientsController.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/partition-coefficients/deactivate",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients/deactivate",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -90,12 +90,12 @@ public class DeactivateCoefficientsController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
     public CoefficientActivationResponse deactivateCoefficients(
             @PathVariable UUID plantId,
-            @PathVariable UUID id,
+            @PathVariable UUID sharingAgreementId,
             @Valid @RequestBody DeactivateCoefficientsBody body) {
-        List<SupplyPartitionCoefficient> touched = service.setValidFrom(plantId, id, null, body.getCoefficientIds());
+        List<SupplyPartitionCoefficient> touched = service.setValidFrom(plantId, sharingAgreementId, null, body.getCoefficientIds());
         return new CoefficientActivationResponse(touched);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/delete/DeleteSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/delete/DeleteSharingAgreementController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
 @RestController
-@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}", produces = MediaType.APPLICATION_JSON_VALUE)
 public class DeleteSharingAgreementController {
 
     private final DeleteSharingAgreementService service;
@@ -83,8 +83,8 @@ public class DeleteSharingAgreementController {
     @BadRequestErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
-    public void deleteSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id) {
-        service.delete(plantId, id);
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
+    public void deleteSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID sharingAgreementId) {
+        service.delete(plantId, sharingAgreementId);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementByIdController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementByIdController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
 @RestController
-@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}", produces = MediaType.APPLICATION_JSON_VALUE)
 public class GetSharingAgreementByIdController {
 
     private final GetSharingAgreementService service;
@@ -63,9 +63,9 @@ public class GetSharingAgreementByIdController {
     @BadRequestErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSharingAgreement(#plantId, #id)")
-    public SharingAgreementResponse getSharingAgreementById(@PathVariable UUID plantId, @PathVariable UUID id) {
-        SharingAgreement sharingAgreement = service.findById(id);
+    @PreAuthorize("@communityAccessGuard.canReadSharingAgreement(#plantId, #sharingAgreementId)")
+    public SharingAgreementResponse getSharingAgreementById(@PathVariable UUID plantId, @PathVariable UUID sharingAgreementId) {
+        SharingAgreement sharingAgreement = service.findById(sharingAgreementId);
         return new SharingAgreementResponse(sharingAgreement);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
 @RestController
-@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/publish", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/publish", produces = MediaType.APPLICATION_JSON_VALUE)
 public class PublishSharingAgreementController {
 
     private final PublishSharingAgreementService service;
@@ -87,9 +87,9 @@ public class PublishSharingAgreementController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
-    public SharingAgreementResponse publishSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id) {
-        SharingAgreement agreement = service.publish(plantId, id);
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
+    public SharingAgreementResponse publishSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID sharingAgreementId) {
+        SharingAgreement agreement = service.publish(plantId, sharingAgreementId);
         return new SharingAgreementResponse(agreement);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/reopen/ReopenCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/reopen/ReopenCoefficientsController.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/partition-coefficients/reopen",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients/reopen",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -86,12 +86,12 @@ public class ReopenCoefficientsController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
     public CoefficientActivationResponse reopenCoefficients(
             @PathVariable UUID plantId,
-            @PathVariable UUID id,
+            @PathVariable UUID sharingAgreementId,
             @Valid @RequestBody ReopenCoefficientsBody body) {
-        List<SupplyPartitionCoefficient> touched = service.setValidTo(plantId, id, null, body.getCoefficientIds());
+        List<SupplyPartitionCoefficient> touched = service.setValidTo(plantId, sharingAgreementId, null, body.getCoefficientIds());
         return new CoefficientActivationResponse(touched);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/GetSharingAgreementFileController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/GetSharingAgreementFileController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/v1/plants/{plantId}/sharing-agreements/{id}/file")
+@RequestMapping("/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/file")
 public class GetSharingAgreementFileController {
 
     private final DownloadSharingAgreementFileService downloadSharingAgreementFileService;
@@ -63,9 +63,9 @@ public class GetSharingAgreementFileController {
     @BadRequestErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canReadSharingAgreement(#plantId, #id)")
-    public ResponseEntity<byte[]> getSharingAgreementFile(@PathVariable UUID plantId, @PathVariable UUID id) {
-        SharingAgreementFile file = downloadSharingAgreementFileService.downloadLatestBySharingAgreementId(id);
+    @PreAuthorize("@communityAccessGuard.canReadSharingAgreement(#plantId, #sharingAgreementId)")
+    public ResponseEntity<byte[]> getSharingAgreementFile(@PathVariable UUID plantId, @PathVariable UUID sharingAgreementId) {
+        SharingAgreementFile file = downloadSharingAgreementFileService.downloadLatestBySharingAgreementId(sharingAgreementId);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileController.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}/file",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/file",
         consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -83,15 +83,15 @@ public class UploadSharingAgreementFileController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
     public UploadSharingAgreementFileResponse uploadSharingAgreementFile(
             @AuthenticationPrincipal User currentUser,
             @PathVariable UUID plantId,
-            @PathVariable UUID id,
+            @PathVariable UUID sharingAgreementId,
             @Parameter(description = "Distributor TXT file. Format: CUPS;coefficient (comma decimal separator). " +
                     "File name must follow the pattern: {regulatoryCode}_{YYYY}.txt.", required = true)
             @RequestParam("file") MultipartFile file) throws IOException {
-        DistributorFileStoreResult result = service.store(plantId, id, file.getOriginalFilename(), file.getBytes(),
+        DistributorFileStoreResult result = service.store(plantId, sharingAgreementId, file.getOriginalFilename(), file.getBytes(),
                 currentUser.getId());
 
         return new UploadSharingAgreementFileResponse(result);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/update/UpdateSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/update/UpdateSharingAgreementController.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping(
-        value = "/api/v1/plants/{plantId}/sharing-agreements/{id}",
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
 )
@@ -96,10 +96,10 @@ public class UpdateSharingAgreementController {
     @ForbiddenErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #id)")
-    public SharingAgreementResponse updateSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID id,
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
+    public SharingAgreementResponse updateSharingAgreement(@PathVariable UUID plantId, @PathVariable UUID sharingAgreementId,
                                                             @Valid @RequestBody UpdateSharingAgreementBody body) {
-        SharingAgreement agreement = service.update(plantId, id, body.mapToUpdateSharingAgreement());
+        SharingAgreement agreement = service.update(plantId, sharingAgreementId, body.mapToUpdateSharingAgreement());
         return new SharingAgreementResponse(agreement);
     }
 }


### PR DESCRIPTION
## Description

Normalizes the REST API URL path parameter naming to the `{resourceId}`
convention. Previously, some endpoints identified resources with a bare `{id}`
segment (e.g. `/api/v1/users/{id}`, `/api/v1/supplies/{id}/consumption/daily`,
`/api/v1/plants/{plantId}/sharing-agreements/{id}`) while others already used
descriptive names (`{communityId}`, `{supplyId}`, `{plantId}`). This PR removes
the ambiguity by renaming every resource identifier in URL paths to
`{resourceId}` (e.g. `{userId}`, `{supplyId}`, `{communityId}`, `{plantId}`,
`{sharingAgreementId}`) and documents the convention in `CLAUDE.md`.

## Changes

- **Controllers (42 files):** renamed the `{id}` path segment to the
  descriptive `{resourceId}` name in `@RequestMapping` / `@GetMapping` /
  `@PutMapping` / `@PostMapping` / `@DeleteMapping` / `@PatchMapping` for:
  - Users (`{userId}`)
  - Supplies CRUD, consumption and production (`{supplyId}`)
  - Communities (`{communityId}`)
  - Memberships (`{communityId}`)
  - Plants (`{plantId}`)
  - Sharing agreements (`{sharingAgreementId}`)
- **`@PathVariable` + Java parameters:** the annotation value and the method
  parameter name now match the URL segment name consistently.
- **`@PreAuthorize`:** updated SpEL expressions that referenced the old
  parameter names (e.g. `#id` → `#supplyId`).
- **`CLAUDE.md`:** added the `{resourceId}` URL path naming convention under
  "Code Standards".

## Impact

This is a **breaking API change** for the affected endpoints. The
`api-docs.json` and the Orval-generated frontend client in `conluz-web` must be
regenerated in lockstep with this change:

```bash
# From conluz-web
npx orval --input ./api-docs.json
```

## Testing

- `./gradlew compileJava` — passes
- `./gradlew test` — all tests pass