### PR TITLE
Feature/conluz 233

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/get/GetSupplyRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/get/GetSupplyRepository.java
@@ -9,6 +9,7 @@ import org.lucoenergia.conluz.domain.shared.pagination.PagedResult;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface GetSupplyRepository {
@@ -17,6 +18,12 @@ public interface GetSupplyRepository {
 
     Optional<Supply> findById(SupplyId id);
     Optional<Supply> findByCode(SupplyCode code);
+
+    /**
+     * Bulk lookup for enriching a list of records that each reference a supply by id, avoiding an
+     * N+1 loop of {@link #findById(SupplyId)} calls.
+     */
+    List<Supply> findAllByIds(Set<UUID> ids);
 
     PagedResult<Supply> findAll(PagedRequest pagedRequest);
     List<Supply> findAll();

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientApplicationState.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientApplicationState.java
@@ -1,0 +1,17 @@
+package org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient;
+
+/**
+ * Whether a coefficient has been applied by the distributor yet.
+ */
+public enum CoefficientApplicationState {
+
+    /**
+     * {@code validFrom} is null: materialised but not yet activated, contributes 0 until applied.
+     */
+    PENDING,
+
+    /**
+     * {@code validFrom} is set.
+     */
+    APPLIED
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientEndState.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientEndState.java
@@ -1,0 +1,40 @@
+package org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient;
+
+/**
+ * How/why a coefficient's coverage ends.
+ */
+public enum CoefficientEndState {
+
+    /**
+     * No {@code validTo}, and no later non-DRAFT agreement exists for the plant at all: this is the
+     * current/last agreement for this supply.
+     */
+    OPEN,
+
+    /**
+     * No {@code validTo}, no next coefficient for this supply in a later agreement, but a later
+     * non-DRAFT agreement of the plant exists: the supply appears to have left without an authored
+     * close -- the end must be authored by hand.
+     */
+    OPEN_ORPHAN,
+
+    /**
+     * No {@code validTo}; the same supply has a next coefficient in a later agreement, but it has not
+     * been applied yet ({@code validFrom} still null).
+     */
+    PENDING_SUCCESSION,
+
+    /**
+     * The end coincides with an already-applied successor coefficient for the same supply -- either
+     * because no {@code validTo} is stored and the next coefficient is already activated, or because
+     * the stored {@code validTo} was written automatically by the activation cascade rather than
+     * authored explicitly.
+     */
+    DERIVED,
+
+    /**
+     * {@code validTo} is stored and was authored explicitly (a close/baja), not written by the
+     * activation cascade. Reopenable via the reopen endpoint.
+     */
+    CLOSED
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientSuccessionCascade.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientSuccessionCascade.java
@@ -1,0 +1,28 @@
+package org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient;
+
+import java.util.Optional;
+
+/**
+ * Whether a coefficient's {@code validTo} was written automatically by the activation cascade
+ * (see {@code CoefficientActivationServiceImpl.setValidFrom}, which closes a predecessor row when
+ * activating its successor) rather than authored explicitly via a close/baja
+ * ({@code CoefficientActivationServiceImpl.setValidTo}).
+ */
+public final class CoefficientSuccessionCascade {
+
+    private CoefficientSuccessionCascade() {
+    }
+
+    /**
+     * {@code coefficient}'s current {@code validTo} is cascade-derived when {@code nextActivated} --
+     * the nearest later activated coefficient for the same {@code (plantId, supplyId)} -- starts
+     * exactly where {@code coefficient} ends. An authored close is not required to be adjacent to
+     * any later row, so any other case (including no later row at all) is not cascade-derived.
+     * Callers must only invoke this when {@code coefficient.getValidTo()} is non-null.
+     */
+    public static boolean isValidToCascadeDerived(SupplyPartitionCoefficient coefficient,
+                                                    Optional<SupplyPartitionCoefficient> nextActivated) {
+        return nextActivated.isPresent()
+                && nextActivated.get().getValidFrom().equals(coefficient.getValidTo());
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/GetSupplyPartitionCoefficientRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/GetSupplyPartitionCoefficientRepository.java
@@ -87,4 +87,19 @@ public interface GetSupplyPartitionCoefficientRepository {
      */
     Optional<SupplyPartitionCoefficient> findNextActivatedAfter(UUID plantId, UUID supplyId, UUID excludeCoefficientId,
                                                                    Instant afterInstant);
+
+    /**
+     * Every coefficient of one sharing agreement, in no particular order.
+     */
+    List<SupplyPartitionCoefficient> findAllBySharingAgreementId(UUID sharingAgreementId);
+
+    /**
+     * The coefficient for {@code (plantId, supplyId)} belonging to the nearest later non-DRAFT
+     * agreement of the plant (by {@code sharing_agreement.created_at} ASC, strictly after
+     * {@code afterAgreementCreatedAt}, excluding {@code excludeSharingAgreementId}) -- regardless of
+     * whether that row is itself activated. DRAFT agreements are always excluded: a draft-in-progress
+     * must never change the displayed state of an existing, already-published row.
+     */
+    Optional<SupplyPartitionCoefficient> findNextCoefficientForSupplyInLaterAgreement(
+            UUID plantId, UUID supplyId, UUID excludeSharingAgreementId, Instant afterAgreementCreatedAt);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsService.java
@@ -18,5 +18,5 @@ public interface GetSharingAgreementPartitionCoefficientsService {
      * @throws SharingAgreementNotFoundException     if no such agreement exists
      * @throws SharingAgreementPlantMismatchException if the agreement does not belong to plantId
      */
-    List<SharingAgreementCoefficientView> findBySharingAgreementId(UUID plantId, UUID sharingAgreementId);
+    List<SharingAgreementCoefficient> findBySharingAgreementId(UUID plantId, UUID sharingAgreementId);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsService.java
@@ -1,0 +1,22 @@
+package org.lucoenergia.conluz.domain.production.sharingagreement.get;
+
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.SharingAgreementPlantMismatchException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service for retrieving a sharing agreement's full, per-supply partition-coefficient set.
+ */
+public interface GetSharingAgreementPartitionCoefficientsService {
+
+    /**
+     * The full coefficient set of {@code sharingAgreementId}, one row per supply, ordered by CUPS
+     * ascending. Works regardless of the agreement's status (DRAFT, PUBLISHED or SUPERSEDED).
+     *
+     * @throws SharingAgreementNotFoundException     if no such agreement exists
+     * @throws SharingAgreementPlantMismatchException if the agreement does not belong to plantId
+     */
+    List<SharingAgreementCoefficientView> findBySharingAgreementId(UUID plantId, UUID sharingAgreementId);
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/GetSharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/GetSharingAgreementRepository.java
@@ -1,5 +1,6 @@
 package org.lucoenergia.conluz.domain.production.sharingagreement.get;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -20,4 +21,12 @@ public interface GetSharingAgreementRepository {
      * Sharing agreements of a plant, newest first. A {@code null} {@code status} means no filter.
      */
     List<SharingAgreement> findByPlantId(UUID plantId, SharingAgreementStatus status);
+
+    /**
+     * Whether any non-DRAFT agreement of {@code plantId}, other than {@code excludeSharingAgreementId},
+     * was created after {@code afterCreatedAt}. DRAFT agreements are always excluded: a
+     * draft-in-progress must never change how an existing, already-published agreement's
+     * coefficients are displayed.
+     */
+    boolean existsLaterNonDraftAgreement(UUID plantId, UUID excludeSharingAgreementId, Instant afterCreatedAt);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/SharingAgreementCoefficient.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/SharingAgreementCoefficient.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  * One row of a sharing agreement's coefficient set, enriched with the supply's display data and
  * the two server-computed states so callers never need to derive interval/successor logic.
  */
-public class SharingAgreementCoefficientView {
+public class SharingAgreementCoefficient {
 
     private final SupplyPartitionCoefficient coefficient;
     private final Supply supply;
@@ -21,9 +21,9 @@ public class SharingAgreementCoefficientView {
     private final CoefficientEndState endState;
     private final Instant endDate;
 
-    public SharingAgreementCoefficientView(SupplyPartitionCoefficient coefficient, Supply supply,
-                                            CoefficientApplicationState applicationState,
-                                            CoefficientEndState endState, Instant endDate) {
+    public SharingAgreementCoefficient(SupplyPartitionCoefficient coefficient, Supply supply,
+                                       CoefficientApplicationState applicationState,
+                                       CoefficientEndState endState, Instant endDate) {
         this.coefficient = coefficient;
         this.supply = supply;
         this.applicationState = applicationState;

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/SharingAgreementCoefficientView.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/get/SharingAgreementCoefficientView.java
@@ -1,0 +1,73 @@
+package org.lucoenergia.conluz.domain.production.sharingagreement.get;
+
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientApplicationState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientEndState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * One row of a sharing agreement's coefficient set, enriched with the supply's display data and
+ * the two server-computed states so callers never need to derive interval/successor logic.
+ */
+public class SharingAgreementCoefficientView {
+
+    private final SupplyPartitionCoefficient coefficient;
+    private final Supply supply;
+    private final CoefficientApplicationState applicationState;
+    private final CoefficientEndState endState;
+    private final Instant endDate;
+
+    public SharingAgreementCoefficientView(SupplyPartitionCoefficient coefficient, Supply supply,
+                                            CoefficientApplicationState applicationState,
+                                            CoefficientEndState endState, Instant endDate) {
+        this.coefficient = coefficient;
+        this.supply = supply;
+        this.applicationState = applicationState;
+        this.endState = endState;
+        this.endDate = endDate;
+    }
+
+    public UUID getCoefficientId() {
+        return coefficient.getId();
+    }
+
+    public UUID getSupplyId() {
+        return supply.getId();
+    }
+
+    public String getSupplyCode() {
+        return supply.getCode();
+    }
+
+    public String getSupplyName() {
+        return supply.getName();
+    }
+
+    public BigDecimal getCoefficient() {
+        return coefficient.getCoefficient();
+    }
+
+    public Instant getValidFrom() {
+        return coefficient.getValidFrom();
+    }
+
+    public Instant getValidTo() {
+        return coefficient.getValidTo();
+    }
+
+    public CoefficientApplicationState getApplicationState() {
+        return applicationState;
+    }
+
+    public CoefficientEndState getEndState() {
+        return endState;
+    }
+
+    public Instant getEndDate() {
+        return endDate;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientJpaRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/SupplyPartitionCoefficientJpaRepository.java
@@ -1,5 +1,6 @@
 package org.lucoenergia.conluz.infrastructure.admin.supply;
 
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -76,6 +77,25 @@ public interface SupplyPartitionCoefficientJpaRepository extends JpaRepository<S
     @Query("SELECT e FROM SupplyPartitionCoefficientEntity e WHERE e.id IN :ids AND e.sharingAgreement.id = :sharingAgreementId")
     List<SupplyPartitionCoefficientEntity> findAllByIdInAndSharingAgreementId(@Param("ids") List<UUID> ids,
                                                                                 @Param("sharingAgreementId") UUID sharingAgreementId);
+
+    List<SupplyPartitionCoefficientEntity> findBySharingAgreementId(UUID sharingAgreementId);
+
+    // The coefficient for (plantId, supplyId) belonging to the nearest later non-DRAFT agreement of
+    // the plant (by sharing_agreement.created_at ASC), regardless of whether that row is itself
+    // activated -- unlike findActivatedAfterOrderByValidFromAsc, which only ever finds activated
+    // rows. DRAFT agreements are always excluded: a draft-in-progress must never change the
+    // displayed state of an existing, already-published row.
+    @Query("SELECT e FROM SupplyPartitionCoefficientEntity e WHERE e.plant.id = :plantId AND e.supply.id = :supplyId " +
+            "AND e.sharingAgreement.status <> :draftStatus AND e.sharingAgreement.createdAt > :afterCreatedAt " +
+            "AND e.sharingAgreement.id <> :excludeAgreementId " +
+            "ORDER BY e.sharingAgreement.createdAt ASC")
+    List<SupplyPartitionCoefficientEntity> findNextCoefficientsForSupplyInLaterAgreements(
+            @Param("plantId") UUID plantId,
+            @Param("supplyId") UUID supplyId,
+            @Param("draftStatus") SharingAgreementStatus draftStatus,
+            @Param("afterCreatedAt") Instant afterCreatedAt,
+            @Param("excludeAgreementId") UUID excludeAgreementId,
+            Pageable pageable);
 
     // The currently open row for (plantId, supplyId), if any -- used when the coefficient being
     // activated has no validFrom of its own yet (pure activation).

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/get/GetSupplyRepositoryDatabase.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Transactional
@@ -100,5 +101,10 @@ public class GetSupplyRepositoryDatabase implements GetSupplyRepository {
     @Override
     public List<Supply> findAllByCommunityId(UUID communityId) {
         return supplyEntityMapper.mapList(supplyRepository.findByCommunityId(communityId));
+    }
+
+    @Override
+    public List<Supply> findAllByIds(Set<UUID> ids) {
+        return supplyEntityMapper.mapList(supplyRepository.findAllById(ids));
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/GetSupplyPartitionCoefficientRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/GetSupplyPartitionCoefficientRepositoryDatabase.java
@@ -2,6 +2,7 @@ package org.lucoenergia.conluz.infrastructure.admin.supply.partitioncoefficient;
 
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.GetSupplyPartitionCoefficientRepository;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementStatus;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientEntity;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientEntityMapper;
 import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyPartitionCoefficientJpaRepository;
@@ -86,6 +87,22 @@ public class GetSupplyPartitionCoefficientRepositoryDatabase implements GetSuppl
     public Optional<SupplyPartitionCoefficient> findNextActivatedAfter(UUID plantId, UUID supplyId,
                                                                          UUID excludeCoefficientId, Instant afterInstant) {
         return jpaRepository.findActivatedAfterOrderByValidFromAsc(plantId, supplyId, excludeCoefficientId, afterInstant,
+                        PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .map(mapper::map);
+    }
+
+    @Override
+    public List<SupplyPartitionCoefficient> findAllBySharingAgreementId(UUID sharingAgreementId) {
+        return mapper.mapList(jpaRepository.findBySharingAgreementId(sharingAgreementId));
+    }
+
+    @Override
+    public Optional<SupplyPartitionCoefficient> findNextCoefficientForSupplyInLaterAgreement(
+            UUID plantId, UUID supplyId, UUID excludeSharingAgreementId, Instant afterAgreementCreatedAt) {
+        return jpaRepository.findNextCoefficientsForSupplyInLaterAgreements(plantId, supplyId,
+                        SharingAgreementStatus.DRAFT, afterAgreementCreatedAt, excludeSharingAgreementId,
                         PageRequest.of(0, 1))
                 .stream()
                 .findFirst()

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/SharingAgreementRepository.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/SharingAgreementRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,4 +40,13 @@ public interface SharingAgreementRepository extends JpaRepository<SharingAgreeme
             WHERE sa.id = :sharingAgreementId AND sa.status <> 'DRAFT'
             """, nativeQuery = true)
     void recomputeStatus(@Param("sharingAgreementId") UUID sharingAgreementId);
+
+    // DRAFT is always excluded: a draft-in-progress can be freely edited or deleted before publish
+    // and must never change how an existing, already-published agreement's coefficients are displayed.
+    @Query("SELECT COUNT(sa) > 0 FROM sharing_agreement sa WHERE sa.plant.id = :plantId " +
+            "AND sa.status <> :draftStatus AND sa.createdAt > :afterCreatedAt AND sa.id <> :excludeId")
+    boolean existsLaterNonDraftAgreement(@Param("plantId") UUID plantId,
+                                          @Param("draftStatus") SharingAgreementStatus draftStatus,
+                                          @Param("afterCreatedAt") Instant afterCreatedAt,
+                                          @Param("excludeId") UUID excludeId);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/activation/CoefficientActivationServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/activation/CoefficientActivationServiceImpl.java
@@ -2,6 +2,7 @@ package org.lucoenergia.conluz.infrastructure.production.sharingagreement.activa
 
 import org.lucoenergia.conluz.domain.admin.supply.Supply;
 import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientSuccessionCascade;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.GetSupplyPartitionCoefficientRepository;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SaveSupplyPartitionCoefficientRepository;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
@@ -165,8 +166,8 @@ public class CoefficientActivationServiceImpl implements CoefficientActivationSe
                 // touch a valid_to you authored, and only up to where the timeline is actually free.
                 Optional<SupplyPartitionCoefficient> nextRow = getCoefficientRepository.findNextActivatedAfter(
                         plantId, coefficient.getSupplyId(), coefficient.getId(), coefficient.getValidFrom());
-                boolean currentValidToIsCascadeDerived = nextRow.isPresent()
-                        && nextRow.get().getValidFrom().equals(coefficient.getValidTo());
+                boolean currentValidToIsCascadeDerived =
+                        CoefficientSuccessionCascade.isValidToCascadeDerived(coefficient, nextRow);
                 boolean requestedValueReachesNextRow = nextRow.isPresent()
                         && (newValidTo == null || newValidTo.isAfter(nextRow.get().getValidFrom()));
                 if (currentValidToIsCascadeDerived || requestedValueReachesNextRow) {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsController.java
@@ -44,12 +44,11 @@ public class GetSharingAgreementPartitionCoefficientsController {
                     Ordered by CUPS ascending. Works regardless of the agreement's status (DRAFT,
                     PUBLISHED or SUPERSEDED).
 
-                    **Required: Community Admin of the plant's community.**
+                    **Required: any member of the plant's community (any role).**
 
                     Returns 404 if the plant does not exist, if the caller is not a member of its
                     community, or if the sharing agreement does not exist or does not belong to this
-                    plant, to avoid leaking the existence of plants or agreements by ID. Returns 403
-                    if the caller is a member of the community but not an admin.
+                    plant, to avoid leaking the existence of plants or agreements by ID.
 
                     Authentication is required using a Bearer token.
                     """,
@@ -69,7 +68,7 @@ public class GetSharingAgreementPartitionCoefficientsController {
     @BadRequestErrorResponse
     @NotFoundErrorResponse
     @InternalServerErrorResponse
-    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
+    @PreAuthorize("@communityAccessGuard.canReadSharingAgreement(#plantId, #sharingAgreementId)")
     public List<SharingAgreementPartitionCoefficientResponse> getPartitionCoefficients(
             @PathVariable UUID plantId, @PathVariable UUID sharingAgreementId) {
         return service.findBySharingAgreementId(plantId, sharingAgreementId).stream()

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsController.java
@@ -1,0 +1,79 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementPartitionCoefficientsService;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
+import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.UnauthorizedErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping(
+        value = "/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+public class GetSharingAgreementPartitionCoefficientsController {
+
+    private final GetSharingAgreementPartitionCoefficientsService service;
+
+    public GetSharingAgreementPartitionCoefficientsController(GetSharingAgreementPartitionCoefficientsService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Retrieves the full partition-coefficient set of a sharing agreement",
+            description = """
+                    Returns one row per supply of the agreement's coefficient set, enriched with the
+                    supply's CUPS code and name, and two server-computed fields (applicationState,
+                    endState) so callers never need to derive interval/successor logic themselves.
+                    Ordered by CUPS ascending. Works regardless of the agreement's status (DRAFT,
+                    PUBLISHED or SUPERSEDED).
+
+                    **Required: Community Admin of the plant's community.**
+
+                    Returns 404 if the plant does not exist, if the caller is not a member of its
+                    community, or if the sharing agreement does not exist or does not belong to this
+                    plant, to avoid leaking the existence of plants or agreements by ID. Returns 403
+                    if the caller is a member of the community but not an admin.
+
+                    Authentication is required using a Bearer token.
+                    """,
+            tags = ApiTag.SHARING_AGREEMENTS,
+            operationId = "getSharingAgreementPartitionCoefficients",
+            security = @SecurityRequirement(name = "bearerToken")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Coefficient set retrieved successfully",
+                    useReturnTypeSchema = true
+            )
+    })
+    @ForbiddenErrorResponse
+    @UnauthorizedErrorResponse
+    @BadRequestErrorResponse
+    @NotFoundErrorResponse
+    @InternalServerErrorResponse
+    @PreAuthorize("@communityAccessGuard.canManageSharingAgreement(#plantId, #sharingAgreementId)")
+    public List<SharingAgreementPartitionCoefficientResponse> getPartitionCoefficients(
+            @PathVariable UUID plantId, @PathVariable UUID sharingAgreementId) {
+        return service.findBySharingAgreementId(plantId, sharingAgreementId).stream()
+                .map(SharingAgreementPartitionCoefficientResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
@@ -97,6 +97,13 @@ public class GetSharingAgreementPartitionCoefficientsServiceImpl implements GetS
                 endState = CoefficientEndState.OPEN_ORPHAN;
                 endDate = null;
             } else if (next.get().getValidFrom() != null) {
+                // Structurally unreachable via this application's own write paths: an activated
+                // "next" row here would mean two overlapping open-ended activated coefficients for
+                // the same (plantId, supplyId) -- the no_overlapping_coefficients exclusion
+                // constraint (and the setValidFrom cascade that closes a predecessor when its
+                // successor activates) makes that impossible. Kept for defensive completeness of the
+                // enum's contract; exercised only at the unit level (mocked repositories), not by an
+                // integration fixture.
                 endState = CoefficientEndState.DERIVED;
                 endDate = next.get().getValidFrom();
             } else {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
@@ -67,15 +67,15 @@ public class GetSharingAgreementPartitionCoefficientsServiceImpl implements GetS
                 plantId, sharingAgreementId, agreement.getCreatedAt());
 
         return coefficients.stream()
-                .map(coefficient -> toView(plantId, agreement, coefficient, suppliesById.get(coefficient.getSupplyId()),
+                .map(coefficient -> map(plantId, agreement, coefficient, suppliesById.get(coefficient.getSupplyId()),
                         laterAgreementExists))
                 .sorted(Comparator.comparing(SharingAgreementCoefficient::getSupplyCode))
                 .toList();
     }
 
-    private SharingAgreementCoefficient toView(UUID plantId, SharingAgreement agreement,
-                                               SupplyPartitionCoefficient coefficient, Supply supply,
-                                               boolean laterAgreementExists) {
+    private SharingAgreementCoefficient map(UUID plantId, SharingAgreement agreement,
+                                            SupplyPartitionCoefficient coefficient, Supply supply,
+                                            boolean laterAgreementExists) {
         CoefficientApplicationState applicationState = coefficient.getValidFrom() == null
                 ? CoefficientApplicationState.PENDING : CoefficientApplicationState.APPLIED;
 

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
@@ -11,7 +11,7 @@ import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreemen
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementPartitionCoefficientsService;
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementService;
-import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficientView;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficient;
 import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.SharingAgreementPlantMismatchException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,7 +44,7 @@ public class GetSharingAgreementPartitionCoefficientsServiceImpl implements GetS
     }
 
     @Override
-    public List<SharingAgreementCoefficientView> findBySharingAgreementId(UUID plantId, UUID sharingAgreementId) {
+    public List<SharingAgreementCoefficient> findBySharingAgreementId(UUID plantId, UUID sharingAgreementId) {
         SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
         if (!agreement.getPlantId().equals(plantId)) {
             throw new SharingAgreementPlantMismatchException(sharingAgreementId, plantId);
@@ -69,13 +69,13 @@ public class GetSharingAgreementPartitionCoefficientsServiceImpl implements GetS
         return coefficients.stream()
                 .map(coefficient -> toView(plantId, agreement, coefficient, suppliesById.get(coefficient.getSupplyId()),
                         laterAgreementExists))
-                .sorted(Comparator.comparing(SharingAgreementCoefficientView::getSupplyCode))
+                .sorted(Comparator.comparing(SharingAgreementCoefficient::getSupplyCode))
                 .toList();
     }
 
-    private SharingAgreementCoefficientView toView(UUID plantId, SharingAgreement agreement,
-                                                     SupplyPartitionCoefficient coefficient, Supply supply,
-                                                     boolean laterAgreementExists) {
+    private SharingAgreementCoefficient toView(UUID plantId, SharingAgreement agreement,
+                                               SupplyPartitionCoefficient coefficient, Supply supply,
+                                               boolean laterAgreementExists) {
         CoefficientApplicationState applicationState = coefficient.getValidFrom() == null
                 ? CoefficientApplicationState.PENDING : CoefficientApplicationState.APPLIED;
 
@@ -112,6 +112,6 @@ public class GetSharingAgreementPartitionCoefficientsServiceImpl implements GetS
             }
         }
 
-        return new SharingAgreementCoefficientView(coefficient, supply, applicationState, endState, endDate);
+        return new SharingAgreementCoefficient(coefficient, supply, applicationState, endState, endDate);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImpl.java
@@ -1,0 +1,110 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
+
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientApplicationState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientEndState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientSuccessionCascade;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.GetSupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementPartitionCoefficientsService;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficientView;
+import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.SharingAgreementPlantMismatchException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class GetSharingAgreementPartitionCoefficientsServiceImpl implements GetSharingAgreementPartitionCoefficientsService {
+
+    private final GetSharingAgreementService getSharingAgreementService;
+    private final GetSharingAgreementRepository getSharingAgreementRepository;
+    private final GetSupplyPartitionCoefficientRepository getCoefficientRepository;
+    private final GetSupplyRepository getSupplyRepository;
+
+    public GetSharingAgreementPartitionCoefficientsServiceImpl(GetSharingAgreementService getSharingAgreementService,
+                                                                 GetSharingAgreementRepository getSharingAgreementRepository,
+                                                                 GetSupplyPartitionCoefficientRepository getCoefficientRepository,
+                                                                 GetSupplyRepository getSupplyRepository) {
+        this.getSharingAgreementService = getSharingAgreementService;
+        this.getSharingAgreementRepository = getSharingAgreementRepository;
+        this.getCoefficientRepository = getCoefficientRepository;
+        this.getSupplyRepository = getSupplyRepository;
+    }
+
+    @Override
+    public List<SharingAgreementCoefficientView> findBySharingAgreementId(UUID plantId, UUID sharingAgreementId) {
+        SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
+        if (!agreement.getPlantId().equals(plantId)) {
+            throw new SharingAgreementPlantMismatchException(sharingAgreementId, plantId);
+        }
+
+        List<SupplyPartitionCoefficient> coefficients = getCoefficientRepository.findAllBySharingAgreementId(sharingAgreementId);
+        if (coefficients.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, Supply> suppliesById = getSupplyRepository.findAllByIds(
+                        coefficients.stream().map(SupplyPartitionCoefficient::getSupplyId).collect(Collectors.toSet()))
+                .stream()
+                .collect(Collectors.toMap(Supply::getId, supply -> supply));
+
+        // Constant for the whole agreement (does not depend on supplyId): computed once so an open
+        // row with no successor (the common case for a freshly-published agreement) resolves to
+        // OPEN directly, without a per-supply lookup.
+        boolean laterAgreementExists = getSharingAgreementRepository.existsLaterNonDraftAgreement(
+                plantId, sharingAgreementId, agreement.getCreatedAt());
+
+        return coefficients.stream()
+                .map(coefficient -> toView(plantId, agreement, coefficient, suppliesById.get(coefficient.getSupplyId()),
+                        laterAgreementExists))
+                .sorted(Comparator.comparing(SharingAgreementCoefficientView::getSupplyCode))
+                .toList();
+    }
+
+    private SharingAgreementCoefficientView toView(UUID plantId, SharingAgreement agreement,
+                                                     SupplyPartitionCoefficient coefficient, Supply supply,
+                                                     boolean laterAgreementExists) {
+        CoefficientApplicationState applicationState = coefficient.getValidFrom() == null
+                ? CoefficientApplicationState.PENDING : CoefficientApplicationState.APPLIED;
+
+        CoefficientEndState endState;
+        Instant endDate;
+        if (coefficient.getValidTo() != null) {
+            Optional<SupplyPartitionCoefficient> nextActivated = getCoefficientRepository.findNextActivatedAfter(
+                    plantId, coefficient.getSupplyId(), coefficient.getId(), coefficient.getValidFrom());
+            endState = CoefficientSuccessionCascade.isValidToCascadeDerived(coefficient, nextActivated)
+                    ? CoefficientEndState.DERIVED : CoefficientEndState.CLOSED;
+            endDate = coefficient.getValidTo();
+        } else if (!laterAgreementExists) {
+            endState = CoefficientEndState.OPEN;
+            endDate = null;
+        } else {
+            Optional<SupplyPartitionCoefficient> next = getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
+                    plantId, coefficient.getSupplyId(), agreement.getId(), agreement.getCreatedAt());
+            if (next.isEmpty()) {
+                endState = CoefficientEndState.OPEN_ORPHAN;
+                endDate = null;
+            } else if (next.get().getValidFrom() != null) {
+                endState = CoefficientEndState.DERIVED;
+                endDate = next.get().getValidFrom();
+            } else {
+                endState = CoefficientEndState.PENDING_SUCCESSION;
+                endDate = null;
+            }
+        }
+
+        return new SharingAgreementCoefficientView(coefficient, supply, applicationState, endState, endDate);
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementRepositoryDatabase.java
@@ -9,6 +9,7 @@ import org.lucoenergia.conluz.infrastructure.production.sharingagreement.Sharing
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,5 +48,12 @@ public class GetSharingAgreementRepositoryDatabase implements GetSharingAgreemen
                 ? sharingAgreementRepository.findByPlantIdOrderByCreatedAtDesc(plantId)
                 : sharingAgreementRepository.findByPlantIdAndStatusOrderByCreatedAtDesc(plantId, status);
         return mapper.mapList(entities);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsLaterNonDraftAgreement(UUID plantId, UUID excludeSharingAgreementId, Instant afterCreatedAt) {
+        return sharingAgreementRepository.existsLaterNonDraftAgreement(
+                plantId, SharingAgreementStatus.DRAFT, afterCreatedAt, excludeSharingAgreementId);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementRepositoryDatabase.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementRepositoryDatabase.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-@Transactional
+@Transactional(readOnly = true)
 @Repository
 public class GetSharingAgreementRepositoryDatabase implements GetSharingAgreementRepository {
 
@@ -28,7 +28,6 @@ public class GetSharingAgreementRepositoryDatabase implements GetSharingAgreemen
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Optional<UUID> findCurrentPublishedAgreementIdByPlantId(UUID plantId) {
         return sharingAgreementRepository
                 .findFirstByPlantIdAndStatusOrderByCreatedAtDesc(plantId, SharingAgreementStatus.PUBLISHED)
@@ -36,13 +35,11 @@ public class GetSharingAgreementRepositoryDatabase implements GetSharingAgreemen
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Optional<SharingAgreement> findById(UUID id) {
         return sharingAgreementRepository.findById(id).map(mapper::map);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<SharingAgreement> findByPlantId(UUID plantId, SharingAgreementStatus status) {
         List<SharingAgreementEntity> entities = status == null
                 ? sharingAgreementRepository.findByPlantIdOrderByCreatedAtDesc(plantId)
@@ -51,7 +48,6 @@ public class GetSharingAgreementRepositoryDatabase implements GetSharingAgreemen
     }
 
     @Override
-    @Transactional(readOnly = true)
     public boolean existsLaterNonDraftAgreement(UUID plantId, UUID excludeSharingAgreementId, Instant afterCreatedAt) {
         return sharingAgreementRepository.existsLaterNonDraftAgreement(
                 plantId, SharingAgreementStatus.DRAFT, afterCreatedAt, excludeSharingAgreementId);

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementCoefficientSupplyResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementCoefficientSupplyResponse.java
@@ -9,7 +9,7 @@ public class SharingAgreementCoefficientSupplyResponse {
     @Schema(description = "Internal unique identifier of the supply", example = "ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c")
     private final UUID id;
 
-    @Schema(description = "CUPS code of the supply", example = "ES0031607648137001RC0F")
+    @Schema(description = "Code of the supply", example = "ES0031607648137001RC0F")
     private final String code;
 
     @Schema(description = "Display name of the supply", example = "John Doe")

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementCoefficientSupplyResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementCoefficientSupplyResponse.java
@@ -1,0 +1,35 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+public class SharingAgreementCoefficientSupplyResponse {
+
+    @Schema(description = "Internal unique identifier of the supply", example = "ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c")
+    private final UUID id;
+
+    @Schema(description = "CUPS code of the supply", example = "ES0031607648137001RC0F")
+    private final String code;
+
+    @Schema(description = "Display name of the supply", example = "John Doe")
+    private final String name;
+
+    public SharingAgreementCoefficientSupplyResponse(UUID id, String code, String name) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementPartitionCoefficientResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementPartitionCoefficientResponse.java
@@ -1,0 +1,100 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientApplicationState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientEndState;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficientView;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public class SharingAgreementPartitionCoefficientResponse {
+
+    @Schema(description = "Internal unique identifier of this coefficient", example = "b3d1a2f0-1234-5678-abcd-000000000001")
+    private final UUID coefficientId;
+
+    @Schema(description = "Supply this coefficient belongs to", example = "ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c")
+    private final UUID supplyId;
+
+    @Schema(description = "CUPS code of the supply", example = "ES0031607648137001RC0F")
+    private final String supplyCode;
+
+    @Schema(description = "Display name of the supply", example = "John Doe")
+    private final String supplyName;
+
+    @Schema(description = "Partition coefficient value, on a 0-1 scale", example = "0.030763")
+    private final BigDecimal coefficient;
+
+    @Schema(description = "Start of the period during which this coefficient is active (inclusive). " +
+            "Null means this is a pending coefficient, materialised but not yet activated.",
+            example = "2024-05-23T00:00:00Z", nullable = true)
+    private final Instant validFrom;
+
+    @Schema(description = "End of the period (exclusive), as stored. Null unless explicitly closed.",
+            example = "2025-01-01T00:00:00Z", nullable = true)
+    private final Instant validTo;
+
+    @Schema(description = "Whether the distributor has applied this coefficient yet")
+    private final CoefficientApplicationState applicationState;
+
+    @Schema(description = "How/why this coefficient's coverage ends")
+    private final CoefficientEndState endState;
+
+    @Schema(description = "The effective end of this coefficient's coverage. Present only when " +
+            "endState is DERIVED or CLOSED.", example = "2025-01-01T00:00:00Z", nullable = true)
+    private final Instant endDate;
+
+    public SharingAgreementPartitionCoefficientResponse(SharingAgreementCoefficientView view) {
+        this.coefficientId = view.getCoefficientId();
+        this.supplyId = view.getSupplyId();
+        this.supplyCode = view.getSupplyCode();
+        this.supplyName = view.getSupplyName();
+        this.coefficient = view.getCoefficient();
+        this.validFrom = view.getValidFrom();
+        this.validTo = view.getValidTo();
+        this.applicationState = view.getApplicationState();
+        this.endState = view.getEndState();
+        this.endDate = view.getEndDate();
+    }
+
+    public UUID getCoefficientId() {
+        return coefficientId;
+    }
+
+    public UUID getSupplyId() {
+        return supplyId;
+    }
+
+    public String getSupplyCode() {
+        return supplyCode;
+    }
+
+    public String getSupplyName() {
+        return supplyName;
+    }
+
+    public BigDecimal getCoefficient() {
+        return coefficient;
+    }
+
+    public Instant getValidFrom() {
+        return validFrom;
+    }
+
+    public Instant getValidTo() {
+        return validTo;
+    }
+
+    public CoefficientApplicationState getApplicationState() {
+        return applicationState;
+    }
+
+    public CoefficientEndState getEndState() {
+        return endState;
+    }
+
+    public Instant getEndDate() {
+        return endDate;
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementPartitionCoefficientResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementPartitionCoefficientResponse.java
@@ -14,14 +14,8 @@ public class SharingAgreementPartitionCoefficientResponse {
     @Schema(description = "Internal unique identifier of this coefficient", example = "b3d1a2f0-1234-5678-abcd-000000000001")
     private final UUID coefficientId;
 
-    @Schema(description = "Supply this coefficient belongs to", example = "ebbe60d1-f9db-455c-8c2d-c34ae7a1c23c")
-    private final UUID supplyId;
-
-    @Schema(description = "CUPS code of the supply", example = "ES0031607648137001RC0F")
-    private final String supplyCode;
-
-    @Schema(description = "Display name of the supply", example = "John Doe")
-    private final String supplyName;
+    @Schema(description = "Supply this coefficient belongs to")
+    private final SharingAgreementCoefficientSupplyResponse supply;
 
     @Schema(description = "Partition coefficient value, on a 0-1 scale", example = "0.030763")
     private final BigDecimal coefficient;
@@ -47,9 +41,7 @@ public class SharingAgreementPartitionCoefficientResponse {
 
     public SharingAgreementPartitionCoefficientResponse(SharingAgreementCoefficientView view) {
         this.coefficientId = view.getCoefficientId();
-        this.supplyId = view.getSupplyId();
-        this.supplyCode = view.getSupplyCode();
-        this.supplyName = view.getSupplyName();
+        this.supply = new SharingAgreementCoefficientSupplyResponse(view.getSupplyId(), view.getSupplyCode(), view.getSupplyName());
         this.coefficient = view.getCoefficient();
         this.validFrom = view.getValidFrom();
         this.validTo = view.getValidTo();
@@ -62,16 +54,8 @@ public class SharingAgreementPartitionCoefficientResponse {
         return coefficientId;
     }
 
-    public UUID getSupplyId() {
-        return supplyId;
-    }
-
-    public String getSupplyCode() {
-        return supplyCode;
-    }
-
-    public String getSupplyName() {
-        return supplyName;
+    public SharingAgreementCoefficientSupplyResponse getSupply() {
+        return supply;
     }
 
     public BigDecimal getCoefficient() {

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementPartitionCoefficientResponse.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/SharingAgreementPartitionCoefficientResponse.java
@@ -3,7 +3,7 @@ package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientApplicationState;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientEndState;
-import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficientView;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficient;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -39,7 +39,7 @@ public class SharingAgreementPartitionCoefficientResponse {
             "endState is DERIVED or CLOSED.", example = "2025-01-01T00:00:00Z", nullable = true)
     private final Instant endDate;
 
-    public SharingAgreementPartitionCoefficientResponse(SharingAgreementCoefficientView view) {
+    public SharingAgreementPartitionCoefficientResponse(SharingAgreementCoefficient view) {
         this.coefficientId = view.getCoefficientId();
         this.supply = new SharingAgreementCoefficientSupplyResponse(view.getSupplyId(), view.getSupplyCode(), view.getSupplyName());
         this.coefficient = view.getCoefficient();

--- a/src/test/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientSuccessionCascadeTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/admin/supply/partitioncoefficient/CoefficientSuccessionCascadeTest.java
@@ -1,0 +1,76 @@
+package org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CoefficientSuccessionCascadeTest {
+
+    private static final Instant VALID_FROM = Instant.parse("2025-01-01T00:00:00Z");
+    private static final Instant VALID_TO = Instant.parse("2025-06-01T00:00:00Z");
+
+    @Test
+    void notCascadeDerived_whenNoLaterActivatedRowExists() {
+        SupplyPartitionCoefficient coefficient = build(VALID_FROM, VALID_TO);
+
+        assertFalse(CoefficientSuccessionCascade.isValidToCascadeDerived(coefficient, Optional.empty()));
+    }
+
+    @Test
+    void notCascadeDerived_whenLaterRowStartsAfterCurrentValidTo() {
+        SupplyPartitionCoefficient coefficient = build(VALID_FROM, VALID_TO);
+        SupplyPartitionCoefficient next = build(VALID_TO.plusSeconds(3600), null);
+
+        assertFalse(CoefficientSuccessionCascade.isValidToCascadeDerived(coefficient, Optional.of(next)));
+    }
+
+    @Test
+    void cascadeDerived_whenLaterRowStartsExactlyAtCurrentValidTo() {
+        // This is exactly the shape CoefficientActivationServiceImpl.setValidFrom writes when
+        // activating a successor: the predecessor's validTo is set to the successor's validFrom.
+        SupplyPartitionCoefficient coefficient = build(VALID_FROM, VALID_TO);
+        SupplyPartitionCoefficient next = build(VALID_TO, null);
+
+        assertTrue(CoefficientSuccessionCascade.isValidToCascadeDerived(coefficient, Optional.of(next)));
+    }
+
+    /**
+     * Documents the invariant relied on by callers: a coefficient can never have {@code validTo}
+     * set while its own {@code validFrom} is still null. Explicit close ({@code setValidTo})
+     * rejects any coefficient whose {@code validFrom} is null (COEFFICIENT_NOT_ACTIVE) before ever
+     * writing a value; the activation cascade ({@code setValidFrom}) only ever writes a new
+     * {@code validTo} onto a predecessor resolved via {@code findPredecessor}, whose backing
+     * queries ({@code findOpenPredecessor}, {@code findPredecessorEndingAt}) both require
+     * {@code validFrom IS NOT NULL} -- so a cascade-closed predecessor always already had its own
+     * {@code validFrom} set. Reaching this state would therefore require a bug elsewhere, not a
+     * legitimate input to this predicate.
+     */
+    @Test
+    void validFromNullWithValidToSet_isStructurallyUnreachable_documentedNotHandled() {
+        SupplyPartitionCoefficient coefficient = build(null, VALID_TO);
+        SupplyPartitionCoefficient next = build(VALID_TO, null);
+
+        // The predicate itself has no opinion on validFrom -- it only compares validTo to the next
+        // row's validFrom -- so this still evaluates correctly even for this unreachable shape.
+        assertTrue(CoefficientSuccessionCascade.isValidToCascadeDerived(coefficient, Optional.of(next)));
+    }
+
+    private static SupplyPartitionCoefficient build(Instant validFrom, Instant validTo) {
+        return new SupplyPartitionCoefficient.Builder()
+                .withId(UUID.randomUUID())
+                .withSupplyId(UUID.randomUUID())
+                .withPlantId(UUID.randomUUID())
+                .withSharingAgreementId(UUID.randomUUID())
+                .withCoefficient(BigDecimal.valueOf(0.5))
+                .withValidFrom(validFrom)
+                .withValidTo(validTo)
+                .withCreatedAt(Instant.now())
+                .build();
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/GetSupplyPartitionCoefficientRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/admin/supply/partitioncoefficient/GetSupplyPartitionCoefficientRepositoryDatabaseTest.java
@@ -68,12 +68,16 @@ class GetSupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegratio
     }
 
     private SharingAgreementEntity persistPublishedAgreement(PlantEntity plant) {
+        return persistAgreement(plant, SharingAgreementStatus.PUBLISHED, Instant.now());
+    }
+
+    private SharingAgreementEntity persistAgreement(PlantEntity plant, SharingAgreementStatus status, Instant createdAt) {
         SharingAgreementEntity agreement = new SharingAgreementEntity();
         agreement.setId(UUID.randomUUID());
         agreement.setPlant(plant);
         agreement.setName("Test agreement " + UUID.randomUUID());
-        agreement.setStatus(SharingAgreementStatus.PUBLISHED);
-        agreement.setCreatedAt(Instant.now());
+        agreement.setStatus(status);
+        agreement.setCreatedAt(createdAt);
         agreement.setCreatedBy(null);
         return sharingAgreementRepository.save(agreement);
     }
@@ -352,6 +356,107 @@ class GetSupplyPartitionCoefficientRepositoryDatabaseTest extends BaseIntegratio
 
         Optional<SupplyPartitionCoefficient> result = repository.findNextActivatedAfter(
                 agreement.getPlant().getId(), supply.getId(), only.getId(), only.getValidFrom());
+
+        assertTrue(result.isEmpty());
+    }
+
+    // --- Sharing-agreement coefficient set read (partition-coefficients GET) ---
+
+    @Test
+    void findAllBySharingAgreementIdReturnsEveryRowOfThatAgreement() {
+        SupplyEntity supply1 = persistSupply();
+        SupplyEntity supply2 = persistSupply();
+        SharingAgreementEntity agreementA = persistPlantAndPublishedAgreement(supply1);
+        SharingAgreementEntity agreementB = persistPublishedAgreement(agreementA.getPlant());
+        persist(supply1.getId(), agreementA.getPlant().getId(), agreementA.getId(), BigDecimal.valueOf(0.4), null, null);
+        persist(supply2.getId(), agreementA.getPlant().getId(), agreementA.getId(), BigDecimal.valueOf(0.6), null, null);
+        persist(supply1.getId(), agreementB.getPlant().getId(), agreementB.getId(), BigDecimal.ONE, null, null);
+
+        List<SupplyPartitionCoefficient> result = repository.findAllBySharingAgreementId(agreementA.getId());
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(c -> c.getSharingAgreementId().equals(agreementA.getId())));
+    }
+
+    @Test
+    void findAllBySharingAgreementIdReturnsEmptyWhenAgreementHasNoCoefficients() {
+        SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
+
+        List<SupplyPartitionCoefficient> result = repository.findAllBySharingAgreementId(agreement.getId());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findNextCoefficientForSupplyInLaterAgreementFindsPendingRow() {
+        SupplyEntity supply = persistSupply();
+        Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
+        SharingAgreementEntity agreementA = persistPlantAndPublishedAgreement(supply);
+        persist(supply.getId(), agreementA.getPlant().getId(), agreementA.getId(), BigDecimal.valueOf(0.5), t0, null);
+        SharingAgreementEntity agreementB = persistAgreement(agreementA.getPlant(), SharingAgreementStatus.PUBLISHED,
+                agreementA.getCreatedAt().plusSeconds(60));
+        SupplyPartitionCoefficient pending = persist(supply.getId(), agreementB.getPlant().getId(), agreementB.getId(),
+                BigDecimal.valueOf(0.5), null, null);
+
+        Optional<SupplyPartitionCoefficient> result = repository.findNextCoefficientForSupplyInLaterAgreement(
+                agreementA.getPlant().getId(), supply.getId(), agreementA.getId(), agreementA.getCreatedAt());
+
+        assertTrue(result.isPresent());
+        assertEquals(pending.getId(), result.get().getId());
+    }
+
+    @Test
+    void findNextCoefficientForSupplyInLaterAgreementFindsActivatedRow() {
+        SupplyEntity supply = persistSupply();
+        Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
+        Instant t1 = Instant.parse("2025-01-01T00:00:00Z");
+        SharingAgreementEntity agreementA = persistPlantAndPublishedAgreement(supply);
+        // Closed (not open-ended) so it does not overlap the successor's open range: a real
+        // successor chain always closes the predecessor at the point the successor takes over.
+        persist(supply.getId(), agreementA.getPlant().getId(), agreementA.getId(), BigDecimal.valueOf(0.5), t0, t1);
+        SharingAgreementEntity agreementB = persistAgreement(agreementA.getPlant(), SharingAgreementStatus.PUBLISHED,
+                agreementA.getCreatedAt().plusSeconds(60));
+        SupplyPartitionCoefficient activated = persist(supply.getId(), agreementB.getPlant().getId(), agreementB.getId(),
+                BigDecimal.valueOf(0.5), t1, null);
+
+        Optional<SupplyPartitionCoefficient> result = repository.findNextCoefficientForSupplyInLaterAgreement(
+                agreementA.getPlant().getId(), supply.getId(), agreementA.getId(), agreementA.getCreatedAt());
+
+        assertTrue(result.isPresent());
+        assertEquals(activated.getId(), result.get().getId());
+    }
+
+    @Test
+    void findNextCoefficientForSupplyInLaterAgreementSkipsDraftAndReturnsNextNonDraft() {
+        SupplyEntity supply = persistSupply();
+        Instant t0 = Instant.parse("2024-01-01T00:00:00Z");
+        SharingAgreementEntity agreementA = persistPlantAndPublishedAgreement(supply);
+        persist(supply.getId(), agreementA.getPlant().getId(), agreementA.getId(), BigDecimal.valueOf(0.5), t0, null);
+        SharingAgreementEntity draftAgreement = persistAgreement(agreementA.getPlant(), SharingAgreementStatus.DRAFT,
+                agreementA.getCreatedAt().plusSeconds(60));
+        persist(supply.getId(), draftAgreement.getPlant().getId(), draftAgreement.getId(), BigDecimal.valueOf(0.5), null, null);
+        SharingAgreementEntity agreementC = persistAgreement(agreementA.getPlant(), SharingAgreementStatus.PUBLISHED,
+                agreementA.getCreatedAt().plusSeconds(120));
+        SupplyPartitionCoefficient nonDraft = persist(supply.getId(), agreementC.getPlant().getId(), agreementC.getId(),
+                BigDecimal.valueOf(0.5), null, null);
+
+        Optional<SupplyPartitionCoefficient> result = repository.findNextCoefficientForSupplyInLaterAgreement(
+                agreementA.getPlant().getId(), supply.getId(), agreementA.getId(), agreementA.getCreatedAt());
+
+        assertTrue(result.isPresent());
+        assertEquals(nonDraft.getId(), result.get().getId());
+    }
+
+    @Test
+    void findNextCoefficientForSupplyInLaterAgreementReturnsEmptyWhenNoneExists() {
+        SupplyEntity supply = persistSupply();
+        SharingAgreementEntity agreement = persistPlantAndPublishedAgreement(supply);
+        persist(supply.getId(), agreement.getPlant().getId(), agreement.getId(), BigDecimal.valueOf(0.5),
+                Instant.parse("2024-01-01T00:00:00Z"), null);
+
+        Optional<SupplyPartitionCoefficient> result = repository.findNextCoefficientForSupplyInLaterAgreement(
+                agreement.getPlant().getId(), supply.getId(), agreement.getId(), agreement.getCreatedAt());
 
         assertTrue(result.isEmpty());
     }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsControllerTest.java
@@ -174,19 +174,20 @@ class GetSharingAgreementPartitionCoefficientsControllerTest extends BaseControl
     }
 
     @Test
-    void returnsForbiddenForCommunityMember() throws Exception {
+    void returnsOkForCommunityMember() throws Exception {
         setUpMultiAgreementFixture();
         String authHeader = loginAsCommunityMember(communityA.getId());
 
         mockMvc.perform(get(url(plantA.getId(), agreement1.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andDo(print())
-                .andExpect(status().isForbidden());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(5)));
     }
 
     @Test
-    void returnsNotFoundForCrossCommunityAdmin() throws Exception {
+    void returnsNotFoundForCrossCommunityMember() throws Exception {
         setUpMultiAgreementFixture();
-        String authHeader = loginAsCommunityAdmin(communityB.getId());
+        String authHeader = loginAsCommunityMember(communityB.getId());
 
         mockMvc.perform(get(url(plantA.getId(), agreement1.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
                 .andDo(print())

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsControllerTest.java
@@ -1,0 +1,292 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
+
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SaveSupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
+import org.lucoenergia.conluz.domain.admin.user.UserMother;
+import org.lucoenergia.conluz.domain.production.plant.PlantMother;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityEntity;
+import org.lucoenergia.conluz.infrastructure.admin.community.CommunityJpaRepository;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntity;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyEntityMother;
+import org.lucoenergia.conluz.infrastructure.admin.supply.SupplyRepository;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserEntity;
+import org.lucoenergia.conluz.infrastructure.admin.user.UserRepository;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantEntity;
+import org.lucoenergia.conluz.infrastructure.production.plant.PlantRepository;
+import org.lucoenergia.conluz.infrastructure.production.sharingagreement.SharingAgreementEntity;
+import org.lucoenergia.conluz.infrastructure.production.sharingagreement.SharingAgreementRepository;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class GetSharingAgreementPartitionCoefficientsControllerTest extends BaseControllerTest {
+
+    private static final String CUPS_CLOSED = "ES0031300325733001AA0F";
+    private static final String CUPS_DERIVED = "ES0031300325733002AA0F";
+    private static final String CUPS_PENDING_SUCCESSION = "ES0031300325733003AA0F";
+    private static final String CUPS_ORPHAN_DRAFT_REGRESSION = "ES0031300325733004AA0F";
+    private static final String CUPS_ORPHAN_NEVER_ACTIVATED = "ES0031300325733005AA0F";
+
+    private static final Instant AGREEMENT_1_CREATED_AT = Instant.parse("2020-01-01T00:00:00Z");
+    private static final Instant AGREEMENT_2_CREATED_AT = Instant.parse("2020-02-01T00:00:00Z");
+    private static final Instant AGREEMENT_3_DRAFT_CREATED_AT = Instant.parse("2020-03-01T00:00:00Z");
+
+    @Autowired
+    private CommunityJpaRepository communityJpaRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SupplyRepository supplyRepository;
+    @Autowired
+    private PlantRepository plantRepository;
+    @Autowired
+    private SharingAgreementRepository sharingAgreementRepository;
+    @Autowired
+    private SaveSupplyPartitionCoefficientRepository saveCoefficientRepository;
+
+    private CommunityEntity communityA;
+    private CommunityEntity communityB;
+    private PlantEntity plantA;
+    private PlantEntity otherPlantInCommunityA;
+    private SharingAgreementEntity agreement1;
+    private SharingAgreementEntity agreement2;
+
+    private CommunityEntity persistCommunity() {
+        return communityJpaRepository.save(CommunityMother.randomEntity().build());
+    }
+
+    private UserEntity persistUser() {
+        return userRepository.save(UserMother.randomUserEntity());
+    }
+
+    private SupplyEntity persistSupply(UserEntity user, CommunityEntity community, String cups, String name) {
+        SupplyEntity supply = SupplyEntityMother.random(user, community);
+        supply.setCode(cups);
+        supply.setName(name);
+        return supplyRepository.save(supply);
+    }
+
+    private PlantEntity persistPlant(SupplyEntity supply) {
+        return plantRepository.save(PlantMother.randomPlantEntity().withSupply(supply).build());
+    }
+
+    private SharingAgreementEntity persistAgreement(PlantEntity plant, SharingAgreementStatus status, Instant createdAt) {
+        SharingAgreementEntity agreement = new SharingAgreementEntity();
+        agreement.setId(UUID.randomUUID());
+        agreement.setPlant(plant);
+        agreement.setName("Test agreement " + UUID.randomUUID());
+        agreement.setStatus(status);
+        agreement.setCreatedAt(createdAt);
+        agreement.setCreatedBy(null);
+        return sharingAgreementRepository.save(agreement);
+    }
+
+    private void persistCoefficient(SupplyEntity supply, PlantEntity plant, SharingAgreementEntity agreement,
+                                     Instant validFrom, Instant validTo) {
+        saveCoefficientRepository.save(new SupplyPartitionCoefficient.Builder()
+                .withId(UUID.randomUUID())
+                .withSupplyId(supply.getId())
+                .withPlantId(plant.getId())
+                .withSharingAgreementId(agreement.getId())
+                .withCoefficient(BigDecimal.valueOf(0.5))
+                .withValidFrom(validFrom)
+                .withValidTo(validTo)
+                .withCreatedAt(Instant.now())
+                .build());
+    }
+
+    private String url(UUID plantId, UUID agreementId) {
+        return "/api/v1/plants/" + plantId + "/sharing-agreements/" + agreementId + "/partition-coefficients";
+    }
+
+    /**
+     * One plant, three agreements (two PUBLISHED, one DRAFT) and five supplies, each engineered to
+     * land in a different endState -- inserted out of CUPS order to make the ordering assertion
+     * meaningful. See the endState-by-supply mapping documented on each persist call below.
+     */
+    private void setUpMultiAgreementFixture() {
+        communityA = persistCommunity();
+        communityB = persistCommunity();
+        UserEntity user = persistUser();
+
+        SupplyEntity supplyOrphanNeverActivated = persistSupply(user, communityA, CUPS_ORPHAN_NEVER_ACTIVATED, "Supply 5");
+        SupplyEntity supplyOrphanDraftRegression = persistSupply(user, communityA, CUPS_ORPHAN_DRAFT_REGRESSION, "Supply 4");
+        SupplyEntity supplyPendingSuccession = persistSupply(user, communityA, CUPS_PENDING_SUCCESSION, "Supply 3");
+        SupplyEntity supplyDerived = persistSupply(user, communityA, CUPS_DERIVED, "Supply 2");
+        SupplyEntity supplyClosed = persistSupply(user, communityA, CUPS_CLOSED, "Supply 1");
+
+        plantA = persistPlant(supplyClosed);
+        otherPlantInCommunityA = persistPlant(persistSupply(user, communityA, "ES0031300325733009AA0F", "Other supply"));
+
+        agreement1 = persistAgreement(plantA, SharingAgreementStatus.PUBLISHED, AGREEMENT_1_CREATED_AT);
+        agreement2 = persistAgreement(plantA, SharingAgreementStatus.PUBLISHED, AGREEMENT_2_CREATED_AT);
+        SharingAgreementEntity agreement3Draft = persistAgreement(plantA, SharingAgreementStatus.DRAFT, AGREEMENT_3_DRAFT_CREATED_AT);
+
+        // CLOSED: authored close, no successor row anywhere -- validTo is not cascade-derived.
+        persistCoefficient(supplyClosed, plantA, agreement1,
+                Instant.parse("2024-01-01T00:00:00Z"), Instant.parse("2024-06-01T00:00:00Z"));
+
+        // DERIVED: agreement1's validTo was written by the activation cascade -- it equals
+        // agreement2's validFrom exactly.
+        Instant handoff = Instant.parse("2024-07-01T00:00:00Z");
+        persistCoefficient(supplyDerived, plantA, agreement1, Instant.parse("2024-01-01T00:00:00Z"), handoff);
+        persistCoefficient(supplyDerived, plantA, agreement2, handoff, null);
+
+        // PENDING_SUCCESSION: agreement1's row is still open (validTo null), and agreement2 has a
+        // row for the same supply that exists but has not been applied yet (validFrom null).
+        persistCoefficient(supplyPendingSuccession, plantA, agreement1, Instant.parse("2024-01-01T00:00:00Z"), null);
+        persistCoefficient(supplyPendingSuccession, plantA, agreement2, null, null);
+
+        // OPEN_ORPHAN (DRAFT-exclusion regression): agreement1's row is open, has no row in
+        // agreement2, but DOES have a pending row in agreement3 -- a DRAFT, which must be ignored,
+        // so this must resolve to OPEN_ORPHAN (agreement2 is a later non-DRAFT agreement), not
+        // PENDING_SUCCESSION (which would wrongly treat the DRAFT row as a real successor).
+        persistCoefficient(supplyOrphanDraftRegression, plantA, agreement1, Instant.parse("2024-01-01T00:00:00Z"), null);
+        persistCoefficient(supplyOrphanDraftRegression, plantA, agreement3Draft, null, null);
+
+        // OPEN_ORPHAN + applicationState=PENDING (independence of the two fields): never activated
+        // at all, but a later non-DRAFT agreement (agreement2) exists for the plant.
+        persistCoefficient(supplyOrphanNeverActivated, plantA, agreement1, null, null);
+    }
+
+    @Test
+    void returnsUnauthorizedWithoutToken() throws Exception {
+        setUpMultiAgreementFixture();
+
+        mockMvc.perform(get(url(plantA.getId(), agreement1.getId())))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void returnsForbiddenForCommunityMember() throws Exception {
+        setUpMultiAgreementFixture();
+        String authHeader = loginAsCommunityMember(communityA.getId());
+
+        mockMvc.perform(get(url(plantA.getId(), agreement1.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void returnsNotFoundForCrossCommunityAdmin() throws Exception {
+        setUpMultiAgreementFixture();
+        String authHeader = loginAsCommunityAdmin(communityB.getId());
+
+        mockMvc.perform(get(url(plantA.getId(), agreement1.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsNotFoundWhenAgreementBelongsToAnotherPlantOfTheSameCommunity() throws Exception {
+        setUpMultiAgreementFixture();
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(get(url(otherPlantInCommunityA.getId(), agreement1.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void returnsAllFiveEndStatesOrderedByCupsWithZeroToOneScale() throws Exception {
+        setUpMultiAgreementFixture();
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(get(url(plantA.getId(), agreement1.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(5)))
+                // Response is CUPS-ascending regardless of the scrambled persist order above.
+                .andExpect(jsonPath("$[0].supplyCode").value(CUPS_CLOSED))
+                .andExpect(jsonPath("$[0].endState").value("CLOSED"))
+                .andExpect(jsonPath("$[0].applicationState").value("APPLIED"))
+                .andExpect(jsonPath("$[0].endDate").value("2024-06-01T00:00:00Z"))
+                .andExpect(jsonPath("$[0].coefficient").value(0.5))
+                .andExpect(jsonPath("$[1].supplyCode").value(CUPS_DERIVED))
+                .andExpect(jsonPath("$[1].endState").value("DERIVED"))
+                .andExpect(jsonPath("$[1].endDate").value("2024-07-01T00:00:00Z"))
+                .andExpect(jsonPath("$[2].supplyCode").value(CUPS_PENDING_SUCCESSION))
+                .andExpect(jsonPath("$[2].endState").value("PENDING_SUCCESSION"))
+                .andExpect(jsonPath("$[2].applicationState").value("APPLIED"))
+                .andExpect(jsonPath("$[2].endDate").value(nullValue()))
+                .andExpect(jsonPath("$[3].supplyCode").value(CUPS_ORPHAN_DRAFT_REGRESSION))
+                .andExpect(jsonPath("$[3].endState").value("OPEN_ORPHAN"))
+                .andExpect(jsonPath("$[3].endDate").value(nullValue()))
+                .andExpect(jsonPath("$[4].supplyCode").value(CUPS_ORPHAN_NEVER_ACTIVATED))
+                .andExpect(jsonPath("$[4].endState").value("OPEN_ORPHAN"))
+                .andExpect(jsonPath("$[4].applicationState").value("PENDING"))
+                .andExpect(jsonPath("$[4].endDate").value(nullValue()))
+                .andExpect(jsonPath("$[4].supplyName").value("Supply 5"));
+    }
+
+    @Test
+    void draftExclusionAlsoAppliesToOpenVsOrphanCheck() throws Exception {
+        // Querying agreement2 itself: only agreement3 (a DRAFT) is later, so its rows resolve to
+        // OPEN, not OPEN_ORPHAN -- proving DRAFT exclusion applies to existsLaterNonDraftAgreement too.
+        setUpMultiAgreementFixture();
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(get(url(plantA.getId(), agreement2.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(2)))
+                .andExpect(jsonPath("$[0].supplyCode").value(CUPS_DERIVED))
+                .andExpect(jsonPath("$[0].endState").value("OPEN"))
+                .andExpect(jsonPath("$[0].applicationState").value("APPLIED"))
+                .andExpect(jsonPath("$[0].endDate").value(nullValue()))
+                .andExpect(jsonPath("$[1].supplyCode").value(CUPS_PENDING_SUCCESSION))
+                .andExpect(jsonPath("$[1].endState").value("OPEN"))
+                .andExpect(jsonPath("$[1].applicationState").value("PENDING"))
+                .andExpect(jsonPath("$[1].endDate").value(nullValue()));
+    }
+
+    @Test
+    void worksWhenTargetAgreementItselfIsDraft() throws Exception {
+        setUpMultiAgreementFixture();
+        SharingAgreementEntity freshDraft = persistAgreement(plantA, SharingAgreementStatus.DRAFT, Instant.now());
+        SupplyEntity supply = supplyRepository.findByCode(CUPS_CLOSED).orElseThrow();
+        persistCoefficient(supply, plantA, freshDraft, null, null);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(get(url(plantA.getId(), freshDraft.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].applicationState").value("PENDING"))
+                .andExpect(jsonPath("$[0].endState").value("OPEN"));
+    }
+
+    @Test
+    void worksWhenTargetAgreementItselfIsSuperseded() throws Exception {
+        setUpMultiAgreementFixture();
+        SharingAgreementEntity superseded = persistAgreement(plantA, SharingAgreementStatus.SUPERSEDED, Instant.now());
+        SupplyEntity supply = supplyRepository.findByCode(CUPS_CLOSED).orElseThrow();
+        persistCoefficient(supply, plantA, superseded,
+                Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-06-01T00:00:00Z"));
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(get(url(plantA.getId(), superseded.getId())).header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].applicationState").value("APPLIED"))
+                .andExpect(jsonPath("$[0].endState").value("CLOSED"))
+                .andExpect(jsonPath("$[0].endDate").value("2023-06-01T00:00:00Z"));
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsControllerTest.java
@@ -213,26 +213,26 @@ class GetSharingAgreementPartitionCoefficientsControllerTest extends BaseControl
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(5)))
                 // Response is CUPS-ascending regardless of the scrambled persist order above.
-                .andExpect(jsonPath("$[0].supplyCode").value(CUPS_CLOSED))
+                .andExpect(jsonPath("$[0].supply.code").value(CUPS_CLOSED))
                 .andExpect(jsonPath("$[0].endState").value("CLOSED"))
                 .andExpect(jsonPath("$[0].applicationState").value("APPLIED"))
                 .andExpect(jsonPath("$[0].endDate").value("2024-06-01T00:00:00Z"))
                 .andExpect(jsonPath("$[0].coefficient").value(0.5))
-                .andExpect(jsonPath("$[1].supplyCode").value(CUPS_DERIVED))
+                .andExpect(jsonPath("$[1].supply.code").value(CUPS_DERIVED))
                 .andExpect(jsonPath("$[1].endState").value("DERIVED"))
                 .andExpect(jsonPath("$[1].endDate").value("2024-07-01T00:00:00Z"))
-                .andExpect(jsonPath("$[2].supplyCode").value(CUPS_PENDING_SUCCESSION))
+                .andExpect(jsonPath("$[2].supply.code").value(CUPS_PENDING_SUCCESSION))
                 .andExpect(jsonPath("$[2].endState").value("PENDING_SUCCESSION"))
                 .andExpect(jsonPath("$[2].applicationState").value("APPLIED"))
                 .andExpect(jsonPath("$[2].endDate").value(nullValue()))
-                .andExpect(jsonPath("$[3].supplyCode").value(CUPS_ORPHAN_DRAFT_REGRESSION))
+                .andExpect(jsonPath("$[3].supply.code").value(CUPS_ORPHAN_DRAFT_REGRESSION))
                 .andExpect(jsonPath("$[3].endState").value("OPEN_ORPHAN"))
                 .andExpect(jsonPath("$[3].endDate").value(nullValue()))
-                .andExpect(jsonPath("$[4].supplyCode").value(CUPS_ORPHAN_NEVER_ACTIVATED))
+                .andExpect(jsonPath("$[4].supply.code").value(CUPS_ORPHAN_NEVER_ACTIVATED))
                 .andExpect(jsonPath("$[4].endState").value("OPEN_ORPHAN"))
                 .andExpect(jsonPath("$[4].applicationState").value("PENDING"))
                 .andExpect(jsonPath("$[4].endDate").value(nullValue()))
-                .andExpect(jsonPath("$[4].supplyName").value("Supply 5"));
+                .andExpect(jsonPath("$[4].supply.name").value("Supply 5"));
     }
 
     @Test
@@ -246,11 +246,11 @@ class GetSharingAgreementPartitionCoefficientsControllerTest extends BaseControl
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(2)))
-                .andExpect(jsonPath("$[0].supplyCode").value(CUPS_DERIVED))
+                .andExpect(jsonPath("$[0].supply.code").value(CUPS_DERIVED))
                 .andExpect(jsonPath("$[0].endState").value("OPEN"))
                 .andExpect(jsonPath("$[0].applicationState").value("APPLIED"))
                 .andExpect(jsonPath("$[0].endDate").value(nullValue()))
-                .andExpect(jsonPath("$[1].supplyCode").value(CUPS_PENDING_SUCCESSION))
+                .andExpect(jsonPath("$[1].supply.code").value(CUPS_PENDING_SUCCESSION))
                 .andExpect(jsonPath("$[1].endState").value("OPEN"))
                 .andExpect(jsonPath("$[1].applicationState").value("PENDING"))
                 .andExpect(jsonPath("$[1].endDate").value(nullValue()));

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImplTest.java
@@ -13,7 +13,7 @@ import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreemen
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementStatus;
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementService;
-import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficientView;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficient;
 import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.SharingAgreementPlantMismatchException;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -95,7 +95,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getSharingAgreementService.findById(agreementId)).thenReturn(agreement(agreementId, PLANT_ID));
         when(getCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(List.of());
 
-        List<SharingAgreementCoefficientView> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
+        List<SharingAgreementCoefficient> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
 
         assertTrue(result.isEmpty());
     }
@@ -111,7 +111,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getCoefficientRepository.findNextActivatedAfter(PLANT_ID, supplyId, row.getId(), row.getValidFrom()))
                 .thenReturn(Optional.empty());
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientEndState.CLOSED, view.getEndState());
         assertEquals(validTo, view.getEndDate());
@@ -130,7 +130,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getCoefficientRepository.findNextActivatedAfter(PLANT_ID, supplyId, row.getId(), row.getValidFrom()))
                 .thenReturn(Optional.of(successor));
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientEndState.DERIVED, view.getEndState());
         assertEquals(validTo, view.getEndDate());
@@ -151,7 +151,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
                 PLANT_ID, supplyId, agreementId, AGREEMENT_CREATED_AT)).thenReturn(Optional.of(successor));
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientEndState.DERIVED, view.getEndState());
         assertEquals(successorValidFrom, view.getEndDate());
@@ -170,7 +170,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
                 PLANT_ID, supplyId, agreementId, AGREEMENT_CREATED_AT)).thenReturn(Optional.of(pendingSuccessor));
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientEndState.PENDING_SUCCESSION, view.getEndState());
         assertNull(view.getEndDate());
@@ -188,7 +188,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
                 PLANT_ID, supplyId, agreementId, AGREEMENT_CREATED_AT)).thenReturn(Optional.empty());
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientEndState.OPEN_ORPHAN, view.getEndState());
         assertNull(view.getEndDate());
@@ -204,7 +204,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
                 .thenReturn(false);
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientEndState.OPEN, view.getEndState());
         assertNull(view.getEndDate());
@@ -222,7 +222,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
                 .thenReturn(false);
 
-        SharingAgreementCoefficientView view = onlyView(agreementId);
+        SharingAgreementCoefficient view = onlyView(agreementId);
 
         assertEquals(CoefficientApplicationState.PENDING, view.getApplicationState());
         assertEquals(CoefficientEndState.OPEN, view.getEndState());
@@ -243,7 +243,7 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
         when(getSharingAgreementRepository.existsLaterNonDraftAgreement(eq(PLANT_ID), eq(agreementId), any()))
                 .thenReturn(false);
 
-        List<SharingAgreementCoefficientView> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
+        List<SharingAgreementCoefficient> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
 
         assertEquals(2, result.size());
         assertEquals("ES0000000000000000AA", result.get(0).getSupplyCode());
@@ -257,8 +257,8 @@ class GetSharingAgreementPartitionCoefficientsServiceImplTest {
                 .thenReturn(List.of(supply(supplyId, "ES0000000000000000AA", "Test supply")));
     }
 
-    private SharingAgreementCoefficientView onlyView(UUID agreementId) {
-        List<SharingAgreementCoefficientView> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
+    private SharingAgreementCoefficient onlyView(UUID agreementId) {
+        List<SharingAgreementCoefficient> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
         assertEquals(1, result.size());
         return result.get(0);
     }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementPartitionCoefficientsServiceImplTest.java
@@ -1,0 +1,265 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.get;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lucoenergia.conluz.domain.admin.supply.Supply;
+import org.lucoenergia.conluz.domain.admin.supply.get.GetSupplyRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientApplicationState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.CoefficientEndState;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.GetSupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementNotFoundException;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementStatus;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementRepository;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementService;
+import org.lucoenergia.conluz.domain.production.sharingagreement.get.SharingAgreementCoefficientView;
+import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.SharingAgreementPlantMismatchException;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetSharingAgreementPartitionCoefficientsServiceImplTest {
+
+    @Mock
+    private GetSharingAgreementService getSharingAgreementService;
+    @Mock
+    private GetSharingAgreementRepository getSharingAgreementRepository;
+    @Mock
+    private GetSupplyPartitionCoefficientRepository getCoefficientRepository;
+    @Mock
+    private GetSupplyRepository getSupplyRepository;
+
+    private static final UUID PLANT_ID = UUID.randomUUID();
+    private static final Instant AGREEMENT_CREATED_AT = Instant.parse("2025-01-01T00:00:00Z");
+
+    private GetSharingAgreementPartitionCoefficientsServiceImpl service() {
+        return new GetSharingAgreementPartitionCoefficientsServiceImpl(
+                getSharingAgreementService, getSharingAgreementRepository, getCoefficientRepository, getSupplyRepository);
+    }
+
+    private SharingAgreement agreement(UUID id, UUID plantId) {
+        return new SharingAgreement.Builder()
+                .withId(id).withPlantId(plantId).withStatus(SharingAgreementStatus.PUBLISHED)
+                .withCreatedAt(AGREEMENT_CREATED_AT).build();
+    }
+
+    private SupplyPartitionCoefficient coefficient(UUID id, UUID agreementId, UUID supplyId,
+                                                     Instant validFrom, Instant validTo) {
+        return new SupplyPartitionCoefficient.Builder()
+                .withId(id).withSupplyId(supplyId).withPlantId(PLANT_ID).withSharingAgreementId(agreementId)
+                .withCoefficient(BigDecimal.valueOf(0.5)).withValidFrom(validFrom).withValidTo(validTo)
+                .withCreatedAt(Instant.EPOCH).build();
+    }
+
+    private Supply supply(UUID id, String code, String name) {
+        return new Supply.Builder().withId(id).withCode(code).withName(name).build();
+    }
+
+    @Test
+    void throwsNotFound_whenAgreementDoesNotExist() {
+        UUID agreementId = UUID.randomUUID();
+        when(getSharingAgreementService.findById(agreementId)).thenThrow(new SharingAgreementNotFoundException(agreementId));
+
+        assertThrows(SharingAgreementNotFoundException.class, () -> service().findBySharingAgreementId(PLANT_ID, agreementId));
+    }
+
+    @Test
+    void throwsPlantMismatch_whenAgreementBelongsToAnotherPlant() {
+        UUID agreementId = UUID.randomUUID();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(agreement(agreementId, UUID.randomUUID()));
+
+        assertThrows(SharingAgreementPlantMismatchException.class,
+                () -> service().findBySharingAgreementId(PLANT_ID, agreementId));
+    }
+
+    @Test
+    void returnsEmptyList_whenAgreementHasNoCoefficients() {
+        UUID agreementId = UUID.randomUUID();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(agreement(agreementId, PLANT_ID));
+        when(getCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(List.of());
+
+        List<SharingAgreementCoefficientView> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void closedState_whenValidToIsAuthoredNotCascadeDerived() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        Instant validTo = Instant.parse("2025-06-01T00:00:00Z");
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId,
+                Instant.parse("2025-01-01T00:00:00Z"), validTo);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getCoefficientRepository.findNextActivatedAfter(PLANT_ID, supplyId, row.getId(), row.getValidFrom()))
+                .thenReturn(Optional.empty());
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientEndState.CLOSED, view.getEndState());
+        assertEquals(validTo, view.getEndDate());
+        assertEquals(CoefficientApplicationState.APPLIED, view.getApplicationState());
+    }
+
+    @Test
+    void derivedState_whenValidToIsCascadeDerived() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        Instant validTo = Instant.parse("2025-06-01T00:00:00Z");
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId,
+                Instant.parse("2025-01-01T00:00:00Z"), validTo);
+        SupplyPartitionCoefficient successor = coefficient(UUID.randomUUID(), UUID.randomUUID(), supplyId, validTo, null);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getCoefficientRepository.findNextActivatedAfter(PLANT_ID, supplyId, row.getId(), row.getValidFrom()))
+                .thenReturn(Optional.of(successor));
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientEndState.DERIVED, view.getEndState());
+        assertEquals(validTo, view.getEndDate());
+    }
+
+    @Test
+    void derivedState_whenValidToIsNullAndNextCoefficientIsActivated() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        Instant successorValidFrom = Instant.parse("2025-06-01T00:00:00Z");
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId,
+                Instant.parse("2025-01-01T00:00:00Z"), null);
+        SupplyPartitionCoefficient successor = coefficient(UUID.randomUUID(), UUID.randomUUID(), supplyId,
+                successorValidFrom, null);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
+                .thenReturn(true);
+        when(getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
+                PLANT_ID, supplyId, agreementId, AGREEMENT_CREATED_AT)).thenReturn(Optional.of(successor));
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientEndState.DERIVED, view.getEndState());
+        assertEquals(successorValidFrom, view.getEndDate());
+    }
+
+    @Test
+    void pendingSuccessionState_whenValidToIsNullAndNextCoefficientIsPending() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId,
+                Instant.parse("2025-01-01T00:00:00Z"), null);
+        SupplyPartitionCoefficient pendingSuccessor = coefficient(UUID.randomUUID(), UUID.randomUUID(), supplyId, null, null);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
+                .thenReturn(true);
+        when(getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
+                PLANT_ID, supplyId, agreementId, AGREEMENT_CREATED_AT)).thenReturn(Optional.of(pendingSuccessor));
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientEndState.PENDING_SUCCESSION, view.getEndState());
+        assertNull(view.getEndDate());
+    }
+
+    @Test
+    void openOrphanState_whenValidToIsNullNoNextCoefficientButLaterAgreementExists() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId,
+                Instant.parse("2025-01-01T00:00:00Z"), null);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
+                .thenReturn(true);
+        when(getCoefficientRepository.findNextCoefficientForSupplyInLaterAgreement(
+                PLANT_ID, supplyId, agreementId, AGREEMENT_CREATED_AT)).thenReturn(Optional.empty());
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientEndState.OPEN_ORPHAN, view.getEndState());
+        assertNull(view.getEndDate());
+    }
+
+    @Test
+    void openState_whenValidToIsNullAndNoLaterAgreementExists_skipsPerSupplyLookup() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId,
+                Instant.parse("2025-01-01T00:00:00Z"), null);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
+                .thenReturn(false);
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientEndState.OPEN, view.getEndState());
+        assertNull(view.getEndDate());
+        // The short-circuit means the per-supply lookup must never even be attempted.
+        org.mockito.Mockito.verify(getCoefficientRepository, org.mockito.Mockito.never())
+                .findNextCoefficientForSupplyInLaterAgreement(any(), any(), any(), any());
+    }
+
+    @Test
+    void applicationStateIsPending_whenValidFromIsNull_independentOfEndState() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyId = UUID.randomUUID();
+        SupplyPartitionCoefficient row = coefficient(UUID.randomUUID(), agreementId, supplyId, null, null);
+        stubAgreementAndCoefficients(agreementId, supplyId, row);
+        when(getSharingAgreementRepository.existsLaterNonDraftAgreement(PLANT_ID, agreementId, AGREEMENT_CREATED_AT))
+                .thenReturn(false);
+
+        SharingAgreementCoefficientView view = onlyView(agreementId);
+
+        assertEquals(CoefficientApplicationState.PENDING, view.getApplicationState());
+        assertEquals(CoefficientEndState.OPEN, view.getEndState());
+    }
+
+    @Test
+    void resultIsSortedByCupsAscending_regardlessOfInputOrder() {
+        UUID agreementId = UUID.randomUUID();
+        UUID supplyIdB = UUID.randomUUID();
+        UUID supplyIdA = UUID.randomUUID();
+        SupplyPartitionCoefficient rowB = coefficient(UUID.randomUUID(), agreementId, supplyIdB, null, null);
+        SupplyPartitionCoefficient rowA = coefficient(UUID.randomUUID(), agreementId, supplyIdA, null, null);
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(agreement(agreementId, PLANT_ID));
+        when(getCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(List.of(rowB, rowA));
+        when(getSupplyRepository.findAllByIds(anySet())).thenReturn(List.of(
+                supply(supplyIdB, "ES0000000000000000ZZ", "Supply B"),
+                supply(supplyIdA, "ES0000000000000000AA", "Supply A")));
+        when(getSharingAgreementRepository.existsLaterNonDraftAgreement(eq(PLANT_ID), eq(agreementId), any()))
+                .thenReturn(false);
+
+        List<SharingAgreementCoefficientView> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
+
+        assertEquals(2, result.size());
+        assertEquals("ES0000000000000000AA", result.get(0).getSupplyCode());
+        assertEquals("ES0000000000000000ZZ", result.get(1).getSupplyCode());
+    }
+
+    private void stubAgreementAndCoefficients(UUID agreementId, UUID supplyId, SupplyPartitionCoefficient row) {
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(agreement(agreementId, PLANT_ID));
+        when(getCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(List.of(row));
+        when(getSupplyRepository.findAllByIds(Set.of(supplyId)))
+                .thenReturn(List.of(supply(supplyId, "ES0000000000000000AA", "Test supply")));
+    }
+
+    private SharingAgreementCoefficientView onlyView(UUID agreementId) {
+        List<SharingAgreementCoefficientView> result = service().findBySharingAgreementId(PLANT_ID, agreementId);
+        assertEquals(1, result.size());
+        return result.get(0);
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementRepositoryDatabaseTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/get/GetSharingAgreementRepositoryDatabaseTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.lucoenergia.conluz.infrastructure.admin.supply.create.CreateSupplyRepositoryDatabase.DEFAULT_COMMUNITY_ID;
 
@@ -151,5 +152,56 @@ class GetSharingAgreementRepositoryDatabaseTest extends BaseIntegrationTest {
 
         assertEquals(1, result.size());
         assertEquals(agreementOfA.getId(), result.get(0).getId());
+    }
+
+    // --- existsLaterNonDraftAgreement ---
+
+    @Test
+    void existsLaterNonDraftAgreement_returnsTrue_whenLaterPublishedAgreementExists() {
+        PlantEntity plant = persistPlant();
+        Instant t0 = Instant.now();
+        SharingAgreementEntity agreement = persistAgreement(plant, SharingAgreementStatus.PUBLISHED, t0);
+        persistAgreement(plant, SharingAgreementStatus.PUBLISHED, t0.plusSeconds(60));
+
+        boolean result = repository.existsLaterNonDraftAgreement(plant.getId(), agreement.getId(), t0);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void existsLaterNonDraftAgreement_returnsFalse_whenOnlyLaterAgreementIsDraft() {
+        PlantEntity plant = persistPlant();
+        Instant t0 = Instant.now();
+        SharingAgreementEntity agreement = persistAgreement(plant, SharingAgreementStatus.PUBLISHED, t0);
+        persistAgreement(plant, SharingAgreementStatus.DRAFT, t0.plusSeconds(60));
+
+        boolean result = repository.existsLaterNonDraftAgreement(plant.getId(), agreement.getId(), t0);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void existsLaterNonDraftAgreement_returnsFalse_whenNoLaterAgreementExists() {
+        PlantEntity plant = persistPlant();
+        Instant t0 = Instant.now();
+        SharingAgreementEntity agreement = persistAgreement(plant, SharingAgreementStatus.PUBLISHED, t0);
+
+        boolean result = repository.existsLaterNonDraftAgreement(plant.getId(), agreement.getId(), t0);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void existsLaterNonDraftAgreement_excludesTheAgreementItself() {
+        PlantEntity plant = persistPlant();
+        Instant t0 = Instant.now();
+        SharingAgreementEntity agreement = persistAgreement(plant, SharingAgreementStatus.PUBLISHED, t0);
+
+        // afterCreatedAt intentionally set before the agreement's own createdAt, so only a bug that
+        // fails to exclude the agreement's own id (rather than the createdAt filter) would pass.
+        boolean result = repository.existsLaterNonDraftAgreement(
+                plant.getId(), agreement.getId(), t0.minusSeconds(1));
+
+        assertFalse(result);
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  Adds a read endpoint for a sharing agreement's full partition-coefficient set, with two server-computed state fields so the frontend never needs to reimplement interval/successor logic:                                
                                                                                                                                                                                                                           
  - `GET /api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/partition-coefficients` — one row per supply, enriched with CUPS code/name, `applicationState` (PENDING/APPLIED), and `endState`                 
  (OPEN/OPEN_ORPHAN/PENDING_SUCCESSION/DERIVED/CLOSED), ordered by CUPS ascending. Guarded by `canManageSharingAgreement` (Community Admin), works regardless of agreement status (DRAFT/PUBLISHED/SUPERSEDED).            
  - Extracts `CoefficientSuccessionCascade.isValidToCascadeDerived` out of `CoefficientActivationServiceImpl` (pure refactor, no behavior change) so the new endpoint reuses the exact same "was this `validTo` written by 
  the activation cascade or authored via an explicit close" check the write path already relied on, instead of a second derivation.                                                                                        
  - Adds three read-only queries needed to compute `endState`: every coefficient of one agreement, the same supply's next coefficient in a later non-DRAFT agreement (regardless of activation state), and whether any     
  later non-DRAFT agreement exists for the plant. DRAFT agreements are always excluded from "later agreement" checks — a draft-in-progress must never change how an existing, published row is displayed.                  
  - `existsLaterNonDraftAgreement` is computed once per agreement rather than once per coefficient; open rows with no later agreement resolve straight to `OPEN`, skipping the per-supply lookup.                          
  - Adds a bulk `GetSupplyRepository.findAllByIds` for enriching the coefficient list without an N+1 loop of `findById` calls.                                                                                             
                                                                                                                                                                                                                           
  No schema change (no Liquibase changeset — all new queries read existing columns), no write/lifecycle behavior changed, no unrequested response wrapper (bare list, matching `GetSharingAgreementsController`'s          
  convention).                                                                                                                                                                                                             
                                                                                                                                                                                                                           
  ## Notable findings                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  - `SUPERSEDED` turned out **not** to be computed via per-coefficient successor lookup (it's a single agreement-level native-SQL aggregate: "has coefficients AND all are closed"). The real successor logic lives only in
  `CoefficientActivationServiceImpl`, and `validTo` can be set either by an authored close *or* by the activation cascade — the extracted predicate disambiguates the two.                                                 
  - Two edge cases proved structurally unreachable given the `no_overlapping_coefficients` exclusion constraint and the existing write paths — documented with comments and unit tests rather than defensive code:         
    - a coefficient can never have `validFrom == null` while `validTo != null`.                                                                                                                                            
    - a coefficient with `validTo == null` (still open) can never have an *activated* "next" coefficient in a later agreement — an open-ended activated row can't coexist with another activated row for the same `(plant, 
  supply)`. That `endState` branch is real code (kept for the enum's contract) but only exercised at the unit/mocked level, not by an integration fixture.                                                                 
  - The new endpoint's guard (`canManageSharingAgreement`, Community Admin) is stricter than the sibling read endpoints (`GetSharingAgreementByIdController`/`GetSharingAgreementsController` use                          
  `canReadSharingAgreement`/`canReadPlant`, any community member) — intentional per the issue spec, but worth double-checking if that divergence from the rest of the agreement read surface is desired long-term.         
                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                             
                                                                                                                                                                                                                           
  - [x] `./gradlew test` — full suite green (1610 tests, 0 failures), including ArchUnit                                                                                                                                   
  - [x] Unit tests for the extracted cascade predicate, including the documented-unreachable invariant                                                                                                                     
  - [x] DB-level tests for the three new repository queries (including DRAFT-exclusion cases)                                                                                                                              
  - [x] Mocked unit tests for the new service covering every `endState`/`applicationState` combination, not-found, plant-mismatch, empty set, sort stability, and the OPEN short-circuit (asserts the per-supply lookup is 
  never invoked)                                                                                                                                                                                                           
  - [x] Integration tests: full 401/403/404/200 auth matrix; all five `endState` values via a multi-supply, multi-agreement (two PUBLISHED + one DRAFT) fixture; DRAFT-exclusion regression for both                       
  OPEN_ORPHAN-vs-PENDING_SUCCESSION and OPEN-vs-OPEN_ORPHAN; independence of `applicationState`/`endState`; 0–1 coefficient scale; CUPS ordering against scrambled insertion order; DRAFT and SUPERSEDED target-agreement  
  status                                                                                                                                                                                                                   
  - [ ] Manual Swagger UI check against a real multi-agreement history (not run in this session — recommend before merge)