### PR TITLE
[conluz-241] Document upload validation-error response (400)

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileController.java
@@ -11,7 +11,6 @@ import org.lucoenergia.conluz.domain.admin.user.User;
 import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.DistributorFileStoreResult;
 import org.lucoenergia.conluz.domain.production.sharingagreement.sharingagreementfile.StoreDistributorFileService;
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.ApiTag;
-import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.BadRequestErrorResponse;
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.ForbiddenErrorResponse;
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.InternalServerErrorResponse;
 import org.lucoenergia.conluz.infrastructure.shared.web.apidocs.response.NotFoundErrorResponse;
@@ -73,12 +72,19 @@ public class UploadSharingAgreementFileController {
                     useReturnTypeSchema = true
             ),
             @ApiResponse(
+                    responseCode = "400",
+                    description = "The file failed validation: one or more of its lines, or the file " +
+                            "as a whole, violate a distributor file rule (e.g. malformed filename, " +
+                            "unknown or duplicate CUPS, invalid coefficient value, coefficient sum not " +
+                            "equal to 1). `errors` lists every violation found, not just the first.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = RestError.class))
+            ),
+            @ApiResponse(
                     responseCode = "409",
                     description = "The agreement is not in DRAFT status.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = RestError.class))
             )
     })
-    @BadRequestErrorResponse
     @UnauthorizedErrorResponse
     @ForbiddenErrorResponse
     @NotFoundErrorResponse

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileControllerApiDocsTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileControllerApiDocsTest.java
@@ -1,0 +1,30 @@
+package org.lucoenergia.conluz.infrastructure.production.sharingagreement.sharingagreementfile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UploadSharingAgreementFileControllerApiDocsTest extends BaseControllerTest {
+
+    @Test
+    void documents400ResponseWithRestErrorSchema() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api-docs"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode response400 = root.path("paths")
+                .path("/api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/file")
+                .path("post")
+                .path("responses")
+                .path("400");
+
+        String ref = response400.path("content").path("application/json").path("schema").path("$ref").asText(null);
+        assertEquals("#/components/schemas/RestError", ref, response400.toString());
+    }
+}

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileControllerTest.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -215,6 +216,40 @@ class UploadSharingAgreementFileControllerTest extends BaseControllerTest {
             }
         }
         return false;
+    }
+
+    @Test
+    void distinguishesFileLevelFromLineLevelErrorsInOneResponse() throws Exception {
+        setUpBaseFixture();
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+        String content = CUPS_1 + ";0,500000\n" + CUPS_2 + ";0,50";
+        MockMultipartFile invalid = new MockMultipartFile("file", FILENAME, TXT_CONTENT_TYPE,
+                content.getBytes(StandardCharsets.UTF_8));
+
+        MvcResult result = mockMvc.perform(multipart(url(plantA.getId(), draftAgreement.getId())).file(invalid)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        JsonNode errors = objectMapper.readTree(result.getResponse().getContentAsString()).get("errors");
+        assertEquals(2, errors.size(), errors.toString());
+
+        JsonNode lineLevel = findByCode(errors, "DISTRIBUTOR_FILE_VALUE_SCALE_INVALID");
+        assertTrue(lineLevel.path("params").has("line"));
+        assertEquals("2", lineLevel.path("params").get("line").asText());
+
+        JsonNode fileLevel = findByCode(errors, "DISTRIBUTOR_FILE_COEFFICIENT_SUM_INVALID");
+        assertFalse(fileLevel.path("params").has("line"));
+    }
+
+    private JsonNode findByCode(JsonNode errors, String code) {
+        for (JsonNode error : errors) {
+            if (error.get("code").asText().equals(code)) {
+                return error;
+            }
+        }
+        throw new AssertionError("No error with code " + code + " in " + errors);
     }
 
     @Test

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/sharingagreementfile/UploadSharingAgreementFileControllerTest.java
@@ -1,5 +1,6 @@
 package org.lucoenergia.conluz.infrastructure.production.sharingagreement.sharingagreementfile;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
 import org.lucoenergia.conluz.domain.admin.user.UserMother;
@@ -20,12 +21,15 @@ import org.lucoenergia.conluz.infrastructure.shared.BaseControllerTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -39,6 +43,7 @@ class UploadSharingAgreementFileControllerTest extends BaseControllerTest {
     private static final String FILENAME = REGULATORY_CODE + "_2024.txt";
     private static final String CUPS_1 = "ES0031300325733001FH0F";
     private static final String CUPS_2 = "ES0031300325733002FH0F";
+    private static final String UNKNOWN_CUPS = "ES0031300325733099FH0F";
     private static final String TXT_CONTENT_TYPE = "text/plain";
 
     @Autowired
@@ -177,6 +182,39 @@ class UploadSharingAgreementFileControllerTest extends BaseControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors").isArray())
                 .andExpect(jsonPath("$.errors[0].code").value("DISTRIBUTOR_FILE_COEFFICIENT_SUM_INVALID"));
+    }
+
+    @Test
+    void returnsAllLineLevelViolationsInASingleResponse() throws Exception {
+        setUpBaseFixture();
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+        String content = CUPS_1 + ";0,500000\n"
+                + CUPS_2 + ";0,50\n"
+                + UNKNOWN_CUPS + ";0,500000\n"
+                + "not-a-valid-line-without-separator";
+        MockMultipartFile invalid = new MockMultipartFile("file", FILENAME, TXT_CONTENT_TYPE,
+                content.getBytes(StandardCharsets.UTF_8));
+
+        MvcResult result = mockMvc.perform(multipart(url(plantA.getId(), draftAgreement.getId())).file(invalid)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        JsonNode errors = objectMapper.readTree(result.getResponse().getContentAsString()).get("errors");
+        assertEquals(3, errors.size(), errors.toString());
+        assertTrue(containsError(errors, "DISTRIBUTOR_FILE_VALUE_SCALE_INVALID", "2"));
+        assertTrue(containsError(errors, "DISTRIBUTOR_FILE_CUPS_UNKNOWN", "3"));
+        assertTrue(containsError(errors, "DISTRIBUTOR_FILE_LINE_MALFORMED", "4"));
+    }
+
+    private boolean containsError(JsonNode errors, String code, String line) {
+        for (JsonNode error : errors) {
+            if (error.get("code").asText().equals(code) && line.equals(error.path("params").path("line").asText(null))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Test


### PR DESCRIPTION
## Summary                                                                                                                                                                                                               
  - The distributor-file upload endpoint (`POST /api/v1/plants/{plantId}/sharing-agreements/{sharingAgreementId}/file`)                                                                                                    
    already returned a structured `400` on validation failure — `DistributorFileParserImpl` accumulates                                                                                                                    
    every offending line in one pass and `SharingAgreementExceptionHandler` maps it to a `RestError` whose                                                                                                                 
    `errors[]` lists all of them at once, file-level (e.g. coefficient sum ≠ 100%) and line-level mixed                                                                                                                    
    together, distinguishable by the presence/absence of a `line` param — but none of this was provable or                                                                                                                 
    documented.                                                                                                                                                                                                            
  - Added regression tests exercising that behavior end-to-end through the real endpoint: all offending                                                                                                                    
    lines reported at once, and file-level vs. line-level errors coexisting and distinguishable in a single                                                                                                                
    response.                                                                                                                                                                                                              
  - Replaced the generic `@BadRequestErrorResponse` on this controller with an inline `@ApiResponse(400, ...)`                                                                                                             
    pointing at `RestError.class` (mirroring the existing 409 entry), so springdoc now documents the real                                                                                                                  
    shape and generated clients can type it.                                                                                                                                                                               
  - No change to which validation rules run, to the success response, or to `@BadRequestErrorResponse`                                                                                                                     
    itself (still used unchanged by other controllers).                                                                                                                                                                    
                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                             
  - [x] New test: multiple simultaneous line-level violations (invalid scale, unknown CUPS, malformed                                                                                                                      
        line) all appear in one `400` response.                                                                                                                                                                            
  - [x] New test: a file-level violation (sum ≠ 100%) and a line-level violation in the same upload both                                                                                                                   
        surface and are distinguishable via the `line` param.                                                                                                                                                              
  - [x] New test: generated OpenAPI (`/api-docs`) references `RestError` as the schema for this endpoint's                                                                                                                 
        `400` response.                                                                                                                                                                                                    
  - [x] Existing upload tests unchanged and green (success path, 409 DRAFT gate, auth matrix).                                                                                                                             
  - [x] Full suite (`./gradlew test`, including ArchUnit) green.