### PR TITLE
[conluz-243] Require installedPowerKw at sharing agreement creation

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/create/CreateSharingAgreement.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/create/CreateSharingAgreement.java
@@ -1,0 +1,71 @@
+package org.lucoenergia.conluz.domain.production.sharingagreement.create;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * The authorable fields of a new sharing agreement. Bundling them here, rather than passing them as
+ * individual parameters to {@link CreateSharingAgreementService}/{@link CreateSharingAgreementRepository},
+ * means adding or removing a field never changes those method signatures.
+ */
+public class CreateSharingAgreement {
+
+    private final String name;
+    private final String notes;
+    private final BigDecimal installedPowerKw;
+    private final UUID createdBy;
+
+    private CreateSharingAgreement(Builder builder) {
+        this.name = builder.name;
+        this.notes = builder.notes;
+        this.installedPowerKw = builder.installedPowerKw;
+        this.createdBy = builder.createdBy;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public BigDecimal getInstalledPowerKw() {
+        return installedPowerKw;
+    }
+
+    public UUID getCreatedBy() {
+        return createdBy;
+    }
+
+    public static class Builder {
+        private String name;
+        private String notes;
+        private BigDecimal installedPowerKw;
+        private UUID createdBy;
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withNotes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public Builder withInstalledPowerKw(BigDecimal installedPowerKw) {
+            this.installedPowerKw = installedPowerKw;
+            return this;
+        }
+
+        public Builder withCreatedBy(UUID createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        public CreateSharingAgreement build() {
+            return new CreateSharingAgreement(this);
+        }
+    }
+}

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/create/CreateSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/create/CreateSharingAgreementService.java
@@ -2,15 +2,17 @@ package org.lucoenergia.conluz.domain.production.sharingagreement.create;
 
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface CreateSharingAgreementService {
 
     /**
      * Creates a new DRAFT sharing agreement under the given plant. {@code installedPowerKw} is
-     * snapshotted from the plant's current {@code totalPower} at creation time, not a live join.
+     * supplied by the caller as a snapshot of the plant's installed power at authoring time, not
+     * read from the plant record.
      *
      * @param createdBy the acting user's id; never null on this path
      */
-    SharingAgreement create(UUID plantId, String name, String notes, UUID createdBy);
+    SharingAgreement create(UUID plantId, String name, String notes, BigDecimal installedPowerKw, UUID createdBy);
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/create/CreateSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/create/CreateSharingAgreementService.java
@@ -2,7 +2,6 @@ package org.lucoenergia.conluz.domain.production.sharingagreement.create;
 
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface CreateSharingAgreementService {
@@ -10,9 +9,8 @@ public interface CreateSharingAgreementService {
     /**
      * Creates a new DRAFT sharing agreement under the given plant. {@code installedPowerKw} is
      * supplied by the caller as a snapshot of the plant's installed power at authoring time, not
-     * read from the plant record.
-     *
-     * @param createdBy the acting user's id; never null on this path
+     * read from the plant record. {@code createdBy} (the acting user's id; never null on this path)
+     * is carried by {@code request}.
      */
-    SharingAgreement create(UUID plantId, String name, String notes, BigDecimal installedPowerKw, UUID createdBy);
+    SharingAgreement create(UUID plantId, CreateSharingAgreement request);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementBody.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreement;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 @Schema(requiredProperties = {"name", "installedPowerKw"})
 public class CreateSharingAgreementBody {
@@ -42,5 +44,14 @@ public class CreateSharingAgreementBody {
 
     public void setInstalledPowerKw(BigDecimal installedPowerKw) {
         this.installedPowerKw = installedPowerKw;
+    }
+
+    public CreateSharingAgreement mapToCreateSharingAgreement(UUID createdBy) {
+        return new CreateSharingAgreement.Builder()
+                .withName(name)
+                .withNotes(notes)
+                .withInstalledPowerKw(installedPowerKw)
+                .withCreatedBy(createdBy)
+                .build();
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementBody.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementBody.java
@@ -2,8 +2,12 @@ package org.lucoenergia.conluz.infrastructure.production.sharingagreement.create
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
-@Schema(requiredProperties = {"name"})
+import java.math.BigDecimal;
+
+@Schema(requiredProperties = {"name", "installedPowerKw"})
 public class CreateSharingAgreementBody {
 
     @Schema(description = "Human-readable label for the agreement", example = "2024 winter distribution")
@@ -11,6 +15,10 @@ public class CreateSharingAgreementBody {
     private String name;
     @Schema(description = "Free-text notes about the agreement", example = "Adjusted after member B joined")
     private String notes;
+    @Schema(description = "Snapshot of the plant's installed power at authoring time, in kW", example = "12.5")
+    @NotNull
+    @Positive
+    private BigDecimal installedPowerKw;
 
     public String getName() {
         return name;
@@ -26,5 +34,13 @@ public class CreateSharingAgreementBody {
 
     public void setNotes(String notes) {
         this.notes = notes;
+    }
+
+    public BigDecimal getInstalledPowerKw() {
+        return installedPowerKw;
+    }
+
+    public void setInstalledPowerKw(BigDecimal installedPowerKw) {
+        this.installedPowerKw = installedPowerKw;
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementController.java
@@ -47,8 +47,9 @@ public class CreateSharingAgreementController {
             summary = "Creates a new sharing agreement under a plant",
             description = """
                     This endpoint creates a new DRAFT sharing agreement under the given plant. The
-                    agreement's installed power is snapshotted from the plant's current total power at
-                    creation time.
+                    agreement's installed power is supplied by the caller as a snapshot of the plant's
+                    installed power at authoring time (the frontend pre-fills it from the plant's
+                    current total power, but it may be edited before submission).
 
                     **Required: Community Admin**
 
@@ -77,7 +78,7 @@ public class CreateSharingAgreementController {
     public SharingAgreementResponse createSharingAgreement(@AuthenticationPrincipal User currentUser,
                                                             @PathVariable UUID plantId,
                                                             @Valid @RequestBody CreateSharingAgreementBody body) {
-        SharingAgreement agreement = service.create(plantId, body.getName(), body.getNotes(), currentUser.getId());
+        SharingAgreement agreement = service.create(plantId, body.getName(), body.getNotes(), body.getInstalledPowerKw(), currentUser.getId());
         return new SharingAgreementResponse(agreement);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementController.java
@@ -78,7 +78,7 @@ public class CreateSharingAgreementController {
     public SharingAgreementResponse createSharingAgreement(@AuthenticationPrincipal User currentUser,
                                                             @PathVariable UUID plantId,
                                                             @Valid @RequestBody CreateSharingAgreementBody body) {
-        SharingAgreement agreement = service.create(plantId, body.getName(), body.getNotes(), body.getInstalledPowerKw(), currentUser.getId());
+        SharingAgreement agreement = service.create(plantId, body.mapToCreateSharingAgreement(currentUser.getId()));
         return new SharingAgreementResponse(agreement);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImpl.java
@@ -1,6 +1,5 @@
 package org.lucoenergia.conluz.infrastructure.production.sharingagreement.create;
 
-import org.lucoenergia.conluz.domain.production.plant.Plant;
 import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreementService;
@@ -29,8 +28,8 @@ public class CreateSharingAgreementServiceImpl implements CreateSharingAgreement
     }
 
     @Override
-    public SharingAgreement create(UUID plantId, String name, String notes, UUID createdBy) {
-        Plant plant = getPlantRepository.findById(PlantId.of(plantId))
+    public SharingAgreement create(UUID plantId, String name, String notes, BigDecimal installedPowerKw, UUID createdBy) {
+        getPlantRepository.findById(PlantId.of(plantId))
                 .orElseThrow(() -> new PlantNotFoundException(PlantId.of(plantId)));
 
         SharingAgreement agreement = new SharingAgreement.Builder()
@@ -39,7 +38,7 @@ public class CreateSharingAgreementServiceImpl implements CreateSharingAgreement
                 .withName(name)
                 .withNotes(notes)
                 .withStatus(SharingAgreementStatus.DRAFT)
-                .withInstalledPowerKw(BigDecimal.valueOf(plant.getTotalPower()))
+                .withInstalledPowerKw(installedPowerKw)
                 .withCreatedAt(Instant.now())
                 .withCreatedBy(createdBy)
                 .build();

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImpl.java
@@ -1,6 +1,7 @@
 package org.lucoenergia.conluz.infrastructure.production.sharingagreement.create;
 
 import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreement;
 import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreementService;
 import org.lucoenergia.conluz.domain.production.plant.get.GetPlantRepository;
@@ -10,7 +11,6 @@ import org.lucoenergia.conluz.domain.shared.PlantId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -28,19 +28,19 @@ public class CreateSharingAgreementServiceImpl implements CreateSharingAgreement
     }
 
     @Override
-    public SharingAgreement create(UUID plantId, String name, String notes, BigDecimal installedPowerKw, UUID createdBy) {
+    public SharingAgreement create(UUID plantId, CreateSharingAgreement request) {
         getPlantRepository.findById(PlantId.of(plantId))
                 .orElseThrow(() -> new PlantNotFoundException(PlantId.of(plantId)));
 
         SharingAgreement agreement = new SharingAgreement.Builder()
                 .withId(UUID.randomUUID())
                 .withPlantId(plantId)
-                .withName(name)
-                .withNotes(notes)
+                .withName(request.getName())
+                .withNotes(request.getNotes())
                 .withStatus(SharingAgreementStatus.DRAFT)
-                .withInstalledPowerKw(installedPowerKw)
+                .withInstalledPowerKw(request.getInstalledPowerKw())
                 .withCreatedAt(Instant.now())
-                .withCreatedBy(createdBy)
+                .withCreatedBy(request.getCreatedBy())
                 .build();
 
         return repository.create(agreement);

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementControllerTest.java
@@ -2,6 +2,8 @@ package org.lucoenergia.conluz.infrastructure.production.sharingagreement.create
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.lucoenergia.conluz.domain.admin.community.Community;
 import org.lucoenergia.conluz.domain.admin.community.CommunityMother;
 import org.lucoenergia.conluz.domain.admin.community.create.CreateCommunityRepository;
@@ -68,7 +70,7 @@ class CreateSharingAgreementControllerTest extends BaseControllerTest {
         mockMvc.perform(post(url(plantA.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"2024 winter distribution\"}"))
+                        .content("{\"name\":\"2024 winter distribution\",\"installedPowerKw\":12.5}"))
                 .andDo(print())
                 .andExpect(status().isForbidden());
     }
@@ -81,7 +83,7 @@ class CreateSharingAgreementControllerTest extends BaseControllerTest {
         mockMvc.perform(post(url(plantA.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"2024 winter distribution\"}"))
+                        .content("{\"name\":\"2024 winter distribution\",\"installedPowerKw\":12.5}"))
                 .andDo(print())
                 .andExpect(status().isNotFound());
     }
@@ -99,21 +101,49 @@ class CreateSharingAgreementControllerTest extends BaseControllerTest {
     }
 
     @Test
-    void createsDraftAgreementWithSnapshottedPowerAndCreator() throws Exception {
+    void createsDraftAgreementWithSuppliedPowerAndCreator() throws Exception {
         String authHeader = loginAsCommunityAdmin(communityA.getId());
+        // Deliberately different from plantA's totalPower, to prove the stored value comes
+        // from the request body and not from a server-side snapshot of the plant.
+        BigDecimal installedPowerKw = BigDecimal.valueOf(plantA.getTotalPower()).add(BigDecimal.ONE);
 
         mockMvc.perform(post(url(plantA.getId()))
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"2024 winter distribution\",\"notes\":\"initial\"}"))
+                        .content("{\"name\":\"2024 winter distribution\",\"notes\":\"initial\",\"installedPowerKw\":" + installedPowerKw + "}"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.plantId").value(plantA.getId().toString()))
                 .andExpect(jsonPath("$.name").value("2024 winter distribution"))
                 .andExpect(jsonPath("$.notes").value("initial"))
                 .andExpect(jsonPath("$.status").value("DRAFT"))
-                .andExpect(jsonPath("$.installedPowerKw").value(BigDecimal.valueOf(plantA.getTotalPower()).doubleValue()))
+                .andExpect(jsonPath("$.installedPowerKw").value(installedPowerKw.doubleValue()))
                 .andExpect(jsonPath("$.createdBy").isNotEmpty());
+    }
+
+    @Test
+    void returnsBadRequestWhenInstalledPowerKwIsMissing() throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"2024 winter distribution\"}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1"})
+    void returnsBadRequestWhenInstalledPowerKwIsNotPositive(String installedPowerKw) throws Exception {
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"2024 winter distribution\",\"installedPowerKw\":" + installedPowerKw + "}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     private Plant createPlant(Community community) {

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImplTest.java
@@ -42,24 +42,25 @@ class CreateSharingAgreementServiceImplTest {
         when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.empty());
 
         assertThrows(PlantNotFoundException.class,
-                () -> service().create(plantId, "name", "notes", UUID.randomUUID()));
+                () -> service().create(plantId, "name", "notes", BigDecimal.TEN, UUID.randomUUID()));
     }
 
     @Test
-    void create_buildsDraftAgreementSnapshottingPlantPower() {
+    void create_buildsDraftAgreementUsingSuppliedPower() {
         UUID plantId = UUID.randomUUID();
         UUID createdBy = UUID.randomUUID();
         Plant plant = PlantMother.random().withId(plantId).withTotalPower(7.25).build();
         when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.of(plant));
         when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        SharingAgreement result = service().create(plantId, "2024 winter distribution", "notes", createdBy);
+        SharingAgreement result = service().create(plantId, "2024 winter distribution", "notes",
+                BigDecimal.valueOf(3.5), createdBy);
 
         assertEquals(plantId, result.getPlantId());
         assertEquals("2024 winter distribution", result.getName());
         assertEquals("notes", result.getNotes());
         assertEquals(SharingAgreementStatus.DRAFT, result.getStatus());
-        assertEquals(0, BigDecimal.valueOf(7.25).compareTo(result.getInstalledPowerKw()));
+        assertEquals(0, BigDecimal.valueOf(3.5).compareTo(result.getInstalledPowerKw()));
         assertEquals(createdBy, result.getCreatedBy());
         assertNotNull(result.getId());
         assertNotNull(result.getCreatedAt());

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/create/CreateSharingAgreementServiceImplTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.lucoenergia.conluz.domain.production.plant.Plant;
 import org.lucoenergia.conluz.domain.production.plant.PlantMother;
 import org.lucoenergia.conluz.domain.production.plant.PlantNotFoundException;
+import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreement;
 import org.lucoenergia.conluz.domain.production.sharingagreement.create.CreateSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.plant.get.GetPlantRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
@@ -40,9 +41,15 @@ class CreateSharingAgreementServiceImplTest {
     void create_throwsPlantNotFound_whenPlantDoesNotExist() {
         UUID plantId = UUID.randomUUID();
         when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.empty());
+        CreateSharingAgreement request = new CreateSharingAgreement.Builder()
+                .withName("name")
+                .withNotes("notes")
+                .withInstalledPowerKw(BigDecimal.TEN)
+                .withCreatedBy(UUID.randomUUID())
+                .build();
 
         assertThrows(PlantNotFoundException.class,
-                () -> service().create(plantId, "name", "notes", BigDecimal.TEN, UUID.randomUUID()));
+                () -> service().create(plantId, request));
     }
 
     @Test
@@ -52,9 +59,14 @@ class CreateSharingAgreementServiceImplTest {
         Plant plant = PlantMother.random().withId(plantId).withTotalPower(7.25).build();
         when(getPlantRepository.findById(PlantId.of(plantId))).thenReturn(Optional.of(plant));
         when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        CreateSharingAgreement request = new CreateSharingAgreement.Builder()
+                .withName("2024 winter distribution")
+                .withNotes("notes")
+                .withInstalledPowerKw(BigDecimal.valueOf(3.5))
+                .withCreatedBy(createdBy)
+                .build();
 
-        SharingAgreement result = service().create(plantId, "2024 winter distribution", "notes",
-                BigDecimal.valueOf(3.5), createdBy);
+        SharingAgreement result = service().create(plantId, request);
 
         assertEquals(plantId, result.getPlantId());
         assertEquals("2024 winter distribution", result.getName());


### PR DESCRIPTION
Summary                                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  - CreateSharingAgreementBody now requires installedPowerKw (BigDecimal, @NotNull @Positive), mirroring UpdateSharingAgreementBody.                                                                                       
  - The create flow stores the value sent by the client instead of snapshotting it server-side from plant.getTotalPower(). The frontend is expected to pre-fill it from the plant's current total power, but the admin may 
  edit it before submitting.                                                                                                                                                                                               
  - The plant lookup in CreateSharingAgreementServiceImpl is kept as a defensive existence check (it's technically redundant with the @PreAuthorize guard, which already 404s on a missing/invisible plant, but removing it
  wasn't in scope for this change).                                                                                                                                                                                        
  - No schema change — the installed_power_kw column already existed and already round-tripped through the response; only its source on create changes.                                                                    
                                                                                                                                                                                                                           
  Test plan                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  - [x] New test asserting the stored/returned installedPowerKw equals the request body value, using a value deliberately different from the plant's totalPower, proving the snapshot behavior was dropped (service +      
  controller level).                                                                                                                                                                                                       
  - [x] installedPowerKw missing → 400.                                                                                                                                                                                    
  - [x] installedPowerKw 0 or negative → 400.                                                                                                                                                                              
  - [x] Updated the two existing 403/404 tests to send a valid installedPowerKw, since body validation now runs before @PreAuthorize — an incomplete body would otherwise mask the intended 403/404 with a 400.            
  - [x] ./gradlew test (full suite, including Testcontainers) passes.