### PR TITLE
Feature/conluz 245

### DIFF
--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/distributorfile/DistributorFileFormat.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/distributorfile/DistributorFileFormat.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.regex.Pattern;
 
 /**
@@ -58,5 +59,17 @@ public final class DistributorFileFormat {
      */
     public static boolean isValidSum(BigDecimal sum) {
         return sum.compareTo(EXPECTED_SUM) == 0;
+    }
+
+    /**
+     * Sums {@code coefficients} after normalizing each to {@link #REQUIRED_DECIMAL_DIGITS} decimal
+     * digits -- the same total {@link #isValidSum} is checked against. Callers that need both the
+     * boolean verdict and the actual sum (e.g. to report it in an error) compute it once here and
+     * pass it to {@link #isValidSum}, instead of duplicating this pipeline inline.
+     */
+    public static BigDecimal normalizedSum(Collection<BigDecimal> coefficients) {
+        return coefficients.stream()
+                .map(DistributorFileFormat::normalizeScale)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 }

--- a/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/publish/PublishSharingAgreementService.java
+++ b/src/main/java/org/lucoenergia/conluz/domain/production/sharingagreement/publish/PublishSharingAgreementService.java
@@ -1,6 +1,7 @@
 package org.lucoenergia.conluz.domain.production.sharingagreement.publish;
 
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementCoefficientSumInvalidException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementHasNoCoefficientsException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementNotDraftException;
 
@@ -15,6 +16,8 @@ public interface PublishSharingAgreementService {
      *         if the agreement is not DRAFT
      * @throws SharingAgreementHasNoCoefficientsException
      *         if the agreement has no partition coefficients yet
+     * @throws SharingAgreementCoefficientSumInvalidException
+     *         if the agreement's coefficients do not sum to exactly 1
      */
     SharingAgreement publish(UUID plantId, UUID sharingAgreementId);
 }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/SharingAgreementExceptionHandler.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/SharingAgreementExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -149,7 +150,8 @@ public class SharingAgreementExceptionHandler {
                 new Object[]{e.getId(), e.getActualSum().toPlainString()},
                 LocaleContextHolder.getLocale()
         );
-        return errorBuilder.build(message, RestErrorCode.SHARING_AGREEMENT_COEFFICIENT_SUM_INVALID, null, HttpStatus.CONFLICT);
+        Map<String, String> params = Map.of("actualSum", e.getActualSum().toPlainString());
+        return errorBuilder.build(message, RestErrorCode.SHARING_AGREEMENT_COEFFICIENT_SUM_INVALID, params, HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(DistributorFileValidationException.class)

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/generatefile/GenerateSharingAgreementFileServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/generatefile/GenerateSharingAgreementFileServiceImpl.java
@@ -64,10 +64,8 @@ public class GenerateSharingAgreementFileServiceImpl implements GenerateSharingA
         // reparto, so every row is exported as-is.
         List<SupplyPartitionCoefficient> coefficients = getCoefficientRepository.findAllBySharingAgreementId(sharingAgreementId);
 
-        BigDecimal sum = coefficients.stream()
-                .map(SupplyPartitionCoefficient::getCoefficient)
-                .map(DistributorFileFormat::normalizeScale)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal sum = DistributorFileFormat.normalizedSum(
+                coefficients.stream().map(SupplyPartitionCoefficient::getCoefficient).toList());
         if (!DistributorFileFormat.isValidSum(sum)) {
             throw new SharingAgreementCoefficientSumInvalidException(sharingAgreementId, sum);
         }

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementController.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementController.java
@@ -47,8 +47,8 @@ public class PublishSharingAgreementController {
 
                     Returns 404 if the plant or the agreement does not exist, does not belong to this
                     plant, or the caller is not a member of its community, to avoid leaking existence.
-                    Returns 409 if the agreement is not in DRAFT status, or if it has no partition
-                    coefficients yet.
+                    Returns 409 if the agreement is not in DRAFT status, if it has no partition
+                    coefficients yet, or if its coefficients do not sum to exactly 1.
 
                     Authentication is required using a Bearer token.
                     """,
@@ -64,7 +64,8 @@ public class PublishSharingAgreementController {
             ),
             @ApiResponse(
                     responseCode = "409",
-                    description = "The agreement is not in DRAFT status, or it has no partition coefficients yet.",
+                    description = "The agreement is not in DRAFT status, it has no partition coefficients yet, " +
+                            "or its coefficients do not sum to exactly 1.",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = RestError.class),

--- a/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementServiceImpl.java
+++ b/src/main/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementServiceImpl.java
@@ -1,14 +1,19 @@
 package org.lucoenergia.conluz.infrastructure.production.sharingagreement.publish;
 
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.GetSupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
+import org.lucoenergia.conluz.domain.production.sharingagreement.distributorfile.DistributorFileFormat;
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementService;
 import org.lucoenergia.conluz.domain.production.sharingagreement.publish.PublishSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.publish.PublishSharingAgreementService;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementCoefficientSumInvalidException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementHasNoCoefficientsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 @Transactional
@@ -31,9 +36,19 @@ public class PublishSharingAgreementServiceImpl implements PublishSharingAgreeme
     public SharingAgreement publish(UUID plantId, UUID sharingAgreementId) {
         SharingAgreement agreement = getSharingAgreementService.findById(sharingAgreementId);
         agreement.assertDraft();
-        if (!supplyPartitionCoefficientRepository.existsBySharingAgreementId(sharingAgreementId)) {
+
+        List<SupplyPartitionCoefficient> coefficients =
+                supplyPartitionCoefficientRepository.findAllBySharingAgreementId(sharingAgreementId);
+        if (coefficients.isEmpty()) {
             throw new SharingAgreementHasNoCoefficientsException(sharingAgreementId);
         }
+
+        BigDecimal sum = DistributorFileFormat.normalizedSum(
+                coefficients.stream().map(SupplyPartitionCoefficient::getCoefficient).toList());
+        if (!DistributorFileFormat.isValidSum(sum)) {
+            throw new SharingAgreementCoefficientSumInvalidException(sharingAgreementId, sum);
+        }
+
         return repository.publish(plantId, sharingAgreementId);
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/domain/production/sharingagreement/distributorfile/DistributorFileFormatTest.java
+++ b/src/test/java/org/lucoenergia/conluz/domain/production/sharingagreement/distributorfile/DistributorFileFormatTest.java
@@ -3,6 +3,7 @@ package org.lucoenergia.conluz.domain.production.sharingagreement.distributorfil
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -63,5 +64,32 @@ class DistributorFileFormatTest {
         assertFalse(DistributorFileFormat.isValidSum(new BigDecimal("1.000001")));
         assertFalse(DistributorFileFormat.isValidSum(new BigDecimal("1.00005")));
         assertFalse(DistributorFileFormat.isValidSum(BigDecimal.ZERO));
+    }
+
+    @Test
+    void normalizedSumOfThreeSharesOnlySumsToOneAtFullScale() {
+        // 1/3 does not terminate; only the six-decimal-scale split sums to exactly 1 -- a naive
+        // double/float comparison of the unrounded shares would never reach equality.
+        BigDecimal sum = DistributorFileFormat.normalizedSum(
+                List.of(new BigDecimal("0.333333"), new BigDecimal("0.333333"), new BigDecimal("0.333334")));
+
+        assertEquals(0, new BigDecimal("1.000000").compareTo(sum));
+        assertTrue(DistributorFileFormat.isValidSum(sum));
+    }
+
+    @Test
+    void normalizedSumPadsShorterCoefficientsBeforeSumming() {
+        BigDecimal sum = DistributorFileFormat.normalizedSum(List.of(new BigDecimal("0.5"), new BigDecimal("0.5")));
+
+        assertEquals(0, new BigDecimal("1.000000").compareTo(sum));
+        assertTrue(DistributorFileFormat.isValidSum(sum));
+    }
+
+    @Test
+    void normalizedSumNotValidWhenCoefficientsDoNotSumToOne() {
+        BigDecimal sum = DistributorFileFormat.normalizedSum(
+                List.of(new BigDecimal("0.500000"), new BigDecimal("0.400000")));
+
+        assertFalse(DistributorFileFormat.isValidSum(sum));
     }
 }

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementControllerTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementControllerTest.java
@@ -33,8 +33,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,6 +67,8 @@ class PublishSharingAgreementControllerTest extends BaseControllerTest {
     private Community communityB;
     private Plant plantA;
     private Supply supplyA;
+    private Supply supplyB;
+    private Supply supplyC;
     private Plant otherPlantInCommunityA;
     private SharingAgreementEntity draftAgreement;
 
@@ -72,6 +77,8 @@ class PublishSharingAgreementControllerTest extends BaseControllerTest {
         communityA = createCommunityRepository.create(CommunityMother.random().build());
         communityB = createCommunityRepository.create(CommunityMother.random().build());
         supplyA = createSupply(communityA);
+        supplyB = createSupply(communityA);
+        supplyC = createSupply(communityA);
         plantA = createPlant(supplyA);
         otherPlantInCommunityA = createPlant(createSupply(communityA));
         draftAgreement = createAgreement(plantA, SharingAgreementStatus.DRAFT);
@@ -127,7 +134,8 @@ class PublishSharingAgreementControllerTest extends BaseControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isConflict());
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errors[0].code").value("SHARING_AGREEMENT_NOT_DRAFT"));
     }
 
     @Test
@@ -138,12 +146,61 @@ class PublishSharingAgreementControllerTest extends BaseControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isConflict());
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errors[0].code").value("SHARING_AGREEMENT_HAS_NO_COEFFICIENTS"));
+    }
+
+    @Test
+    void returnsConflictWhenCoefficientSumIsLessThanOne() throws Exception {
+        seedCoefficients(draftAgreement, new BigDecimal("0.300000"), new BigDecimal("0.300000"));
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errors[0].code").value("SHARING_AGREEMENT_COEFFICIENT_SUM_INVALID"))
+                .andExpect(jsonPath("$.errors[0].params.actualSum").value("0.600000"));
+
+        assertAgreementIsStillDraftWithUnchangedCoefficients(new BigDecimal("0.300000"), new BigDecimal("0.300000"));
+    }
+
+    @Test
+    void returnsConflictWhenCoefficientSumIsGreaterThanOne() throws Exception {
+        seedCoefficients(draftAgreement, new BigDecimal("0.700000"), new BigDecimal("0.700000"));
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errors[0].code").value("SHARING_AGREEMENT_COEFFICIENT_SUM_INVALID"))
+                .andExpect(jsonPath("$.errors[0].params.actualSum").value("1.400000"));
+
+        assertAgreementIsStillDraftWithUnchangedCoefficients(new BigDecimal("0.700000"), new BigDecimal("0.700000"));
     }
 
     @Test
     void publishesDraftAgreementWithCoefficients() throws Exception {
         seedCoefficient(supplyA, plantA, draftAgreement);
+        String authHeader = loginAsCommunityAdmin(communityA.getId());
+
+        mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
+                        .header(HttpHeaders.AUTHORIZATION, authHeader)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(draftAgreement.getId().toString()))
+                .andExpect(jsonPath("$.status").value("PUBLISHED"));
+    }
+
+    @Test
+    void publishesDraftAgreementWithCoefficientsSummingToOneOnlyAtFullScale() throws Exception {
+        // 1/3 does not terminate; only the six-decimal-scale split sums to exactly 1 -- this would
+        // fail under a naive double/float equality check.
+        seedCoefficients(draftAgreement, new BigDecimal("0.333333"), new BigDecimal("0.333333"), new BigDecimal("0.333334"));
         String authHeader = loginAsCommunityAdmin(communityA.getId());
 
         mockMvc.perform(post(url(plantA.getId(), draftAgreement.getId()))
@@ -193,6 +250,41 @@ class PublishSharingAgreementControllerTest extends BaseControllerTest {
         coefficient.setValidFrom(Instant.now());
         coefficient.setCreatedAt(Instant.now());
         supplyPartitionCoefficientJpaRepository.save(coefficient);
+    }
+
+    /**
+     * Seeds one coefficient row per value on {@code draftAgreement}/{@code plantA}, drawn from
+     * {@code supplyA}/{@code supplyB}/{@code supplyC} in order. Supports up to three values.
+     */
+    private void seedCoefficients(SharingAgreementEntity agreement, BigDecimal... values) {
+        List<Supply> supplies = List.of(supplyA, supplyB, supplyC);
+        PlantEntity plantEntity = plantRepository.getReferenceById(plantA.getId());
+        SharingAgreementEntity agreementReference = sharingAgreementRepository.getReferenceById(agreement.getId());
+        for (int i = 0; i < values.length; i++) {
+            SupplyEntity supplyEntity = supplyRepository.getReferenceById(supplies.get(i).getId());
+
+            SupplyPartitionCoefficientEntity coefficient = new SupplyPartitionCoefficientEntity();
+            coefficient.setId(UUID.randomUUID());
+            coefficient.setSupply(supplyEntity);
+            coefficient.setPlant(plantEntity);
+            coefficient.setSharingAgreement(agreementReference);
+            coefficient.setCoefficient(values[i]);
+            coefficient.setValidFrom(null);
+            coefficient.setCreatedAt(Instant.now());
+            supplyPartitionCoefficientJpaRepository.save(coefficient);
+        }
+    }
+
+    private void assertAgreementIsStillDraftWithUnchangedCoefficients(BigDecimal... expectedValues) {
+        SharingAgreementEntity refreshed = sharingAgreementRepository.findById(draftAgreement.getId()).orElseThrow();
+        assertEquals(SharingAgreementStatus.DRAFT, refreshed.getStatus());
+
+        List<SupplyPartitionCoefficientEntity> coefficients = supplyPartitionCoefficientJpaRepository
+                .findBySharingAgreementId(draftAgreement.getId());
+        assertEquals(expectedValues.length, coefficients.size());
+        for (BigDecimal expected : expectedValues) {
+            assertTrue(coefficients.stream().anyMatch(c -> expected.compareTo(c.getCoefficient()) == 0));
+        }
     }
 
     private String url(UUID plantId, UUID agreementId) {

--- a/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementServiceImplTest.java
+++ b/src/test/java/org/lucoenergia/conluz/infrastructure/production/sharingagreement/publish/PublishSharingAgreementServiceImplTest.java
@@ -3,9 +3,11 @@ package org.lucoenergia.conluz.infrastructure.production.sharingagreement.publis
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.GetSupplyPartitionCoefficientRepository;
+import org.lucoenergia.conluz.domain.admin.supply.partitioncoefficient.SupplyPartitionCoefficient;
 import org.lucoenergia.conluz.domain.production.sharingagreement.get.GetSharingAgreementService;
 import org.lucoenergia.conluz.domain.production.sharingagreement.publish.PublishSharingAgreementRepository;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreement;
+import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementCoefficientSumInvalidException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementHasNoCoefficientsException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementNotDraftException;
 import org.lucoenergia.conluz.domain.production.sharingagreement.SharingAgreementStatus;
@@ -13,6 +15,8 @@ import org.lucoenergia.conluz.infrastructure.production.sharingagreement.publish
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,6 +40,14 @@ class PublishSharingAgreementServiceImplTest {
         return new PublishSharingAgreementServiceImpl(getSharingAgreementService, supplyPartitionCoefficientRepository, repository);
     }
 
+    private SupplyPartitionCoefficient coefficient(BigDecimal value) {
+        return new SupplyPartitionCoefficient.Builder()
+                .withId(UUID.randomUUID())
+                .withSupplyId(UUID.randomUUID())
+                .withCoefficient(value)
+                .build();
+    }
+
     @Test
     void publish_throwsNotDraft_whenAgreementIsPublished() {
         UUID agreementId = UUID.randomUUID();
@@ -46,7 +58,7 @@ class PublishSharingAgreementServiceImplTest {
         when(getSharingAgreementService.findById(agreementId)).thenReturn(published);
 
         assertThrows(SharingAgreementNotDraftException.class, () -> service().publish(UUID.randomUUID(), agreementId));
-        verify(supplyPartitionCoefficientRepository, never()).existsBySharingAgreementId(agreementId);
+        verify(supplyPartitionCoefficientRepository, never()).findAllBySharingAgreementId(agreementId);
     }
 
     @Test
@@ -57,7 +69,7 @@ class PublishSharingAgreementServiceImplTest {
                 .withStatus(SharingAgreementStatus.DRAFT)
                 .build();
         when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
-        when(supplyPartitionCoefficientRepository.existsBySharingAgreementId(agreementId)).thenReturn(false);
+        when(supplyPartitionCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(List.of());
 
         assertThrows(SharingAgreementHasNoCoefficientsException.class,
                 () -> service().publish(UUID.randomUUID(), agreementId));
@@ -65,7 +77,27 @@ class PublishSharingAgreementServiceImplTest {
     }
 
     @Test
-    void publish_delegatesToRepository_whenDraftWithCoefficients() {
+    void publish_throwsSumInvalid_whenCoefficientsDoNotSumToOne() {
+        UUID agreementId = UUID.randomUUID();
+        SharingAgreement draft = new SharingAgreement.Builder()
+                .withId(agreementId)
+                .withStatus(SharingAgreementStatus.DRAFT)
+                .build();
+        when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
+        List<SupplyPartitionCoefficient> coefficients = List.of(
+                coefficient(new BigDecimal("0.500000")),
+                coefficient(new BigDecimal("0.400000")));
+        when(supplyPartitionCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(coefficients);
+
+        SharingAgreementCoefficientSumInvalidException e = assertThrows(SharingAgreementCoefficientSumInvalidException.class,
+                () -> service().publish(UUID.randomUUID(), agreementId));
+
+        assertEquals(0, new BigDecimal("0.900000").compareTo(e.getActualSum()));
+        verify(repository, never()).publish(any(), any());
+    }
+
+    @Test
+    void publish_delegatesToRepository_whenDraftWithCoefficientsSummingToOne() {
         UUID plantId = UUID.randomUUID();
         UUID agreementId = UUID.randomUUID();
         SharingAgreement draft = new SharingAgreement.Builder()
@@ -73,7 +105,11 @@ class PublishSharingAgreementServiceImplTest {
                 .withStatus(SharingAgreementStatus.DRAFT)
                 .build();
         when(getSharingAgreementService.findById(agreementId)).thenReturn(draft);
-        when(supplyPartitionCoefficientRepository.existsBySharingAgreementId(agreementId)).thenReturn(true);
+        List<SupplyPartitionCoefficient> coefficients = List.of(
+                coefficient(new BigDecimal("0.333333")),
+                coefficient(new BigDecimal("0.333333")),
+                coefficient(new BigDecimal("0.333334")));
+        when(supplyPartitionCoefficientRepository.findAllBySharingAgreementId(agreementId)).thenReturn(coefficients);
         SharingAgreement published = new SharingAgreement.Builder()
                 .withId(agreementId)
                 .withStatus(SharingAgreementStatus.PUBLISHED)


### PR DESCRIPTION
Summary                                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  Publishing a sharing agreement (POST .../sharing-agreements/{id}/publish) previously checked only that it was DRAFT and had at least one coefficient — not that the coefficient set summed to 1. Since publishing seals  
  the set permanently and distributor-file generation later rejects any set that doesn't sum to exactly 1.000000, a non-conforming set could be published into a state that could never produce its distributor file,      
  recoverable only while still unactivated (revert-to-draft).                                                                                                                                                              
                                                                                                                                                                                                                           
  - Extracted the existing generate-file sum rule (DistributorFileFormat.normalizedSum + isValidSum, exact equality at 6-decimal scale) into a shared method, and reused it — unchanged — at publish, instead of           
  introducing a new or looser rule. Publish can now never accept a set that generate-file would later reject.                                                                                                              
  - publish checks the sum after the existing DRAFT and empty-set checks, reusing the existing SHARING_AGREEMENT_COEFFICIENT_SUM_INVALID error code (no new code added) and populating params.actualSum, matching the      
  convention already used by the equivalent distributor-file upload error.                                                                                                                                                 
  - The manual coefficient-replace endpoint's own ±0.0001 soft warning (coefficientSumWarning) is intentionally left untouched — it's a separate, already-documented UX nudge on a still-mutable DRAFT set, not a gate.    
                                                                                                                                                                                                                           
  Test plan                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  - [x] PublishSharingAgreementControllerTest: sum < 1 and sum > 1 both return 409 with the sum code and params.actualSum, and leave the agreement DRAFT with coefficients unchanged; a rounding-sensitive 3-way split     
  (0.333333/0.333333/0.333334) that only equals 1 at full 6-decimal scale succeeds; existing not-draft / no-coefficients 409s now assert their specific error codes to pin down check ordering.                            
  - [x] PublishSharingAgreementServiceImplTest: unit coverage for the same cases, mocked at the repository boundary.                                                                                                       
  - [x] DistributorFileFormatTest: unit coverage for normalizedSum including the same rounding-sensitive case, no Spring context.                                                                                          
  - [x] Full existing suite (incl. GenerateSharingAgreementFileControllerTest/*ServiceImplTest, ArchUnit) passes unchanged.                                                                                                
  - [ ] Manual: none needed — no schema/migration changes, no frontend changes.   