### PR TITLE
Feature/conluzinfra 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: run debug
+
+run:
+	./gradlew bootRun --args='--spring.profiles.active=local'
+
+debug:
+	./gradlew bootRun --debug-jvm --args='--spring.profiles.active=local'

--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ If you have your InfluxDB running with a different server, port, user credential
 
     The application will be accessible at https://localhost:8443.
 
+### Local development
+
+For day-to-day local development, conluz-infra provisions a local Postgres (port 5433) and
+InfluxDB (port 8087) with anonymized data. Bring those up first (see conluz-infra's local
+setup), then from this repo run:
+
+```bash
+make run    # ./gradlew bootRun --args='--spring.profiles.active=local'
+make debug  # same, with the JVM debug port open for attaching a debugger
+```
+
+Both targets activate the `local` Spring profile (`src/main/resources/application-local.properties`),
+which points at those services using `luz`/`blank` on both — a fixed, non-secret local dev
+convention, not a credential to protect (see [Already existing InfluxDB
+installation](#already-existing-influxdb-installation) above for the same convention).
+
+> **Note:**
+>
+> The JWT secret in `application-local.properties` is only used if the `CONLUZ_JWT_SECRET_KEY`
+> environment variable is **not** already set in your shell — that variable always takes
+> precedence over the profile's value. If you've previously exported a real secret (e.g. copied
+> from a production `.env`), `unset CONLUZ_JWT_SECRET_KEY` before running locally.
+
 
 ## Usage
 

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:postgresql://localhost:5433/conluz_db
+spring.datasource.username=luz
+spring.datasource.password=blank
+
+spring.influxdb.url=http://localhost:8087
+spring.influxdb.username=luz
+spring.influxdb.password=blank
+spring.influxdb.database=conluz_db
+
+conluz.security.jwt.secret-key=local-dev-only-not-a-secret-DO-NOT-USE-IN-PRODUCTION-0000000000

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,8 +6,8 @@
         </encoder>
     </appender>
 
-    <!-- Development and Testing environment -->
-    <springProfile name="dev,test">
+    <!-- Development and Testing environments -->
+    <springProfile name="dev,test,local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>


### PR DESCRIPTION
1. ab8ebf8f — src/main/resources/application-local.properties: local profile with the exact keys already used by the app, pointing at localhost:5433/5433 Postgres and localhost:8087 InfluxDB with luz/blank, plus a    
  low-entropy dummy JWT value verified against gitleaks before committing.                                                                                                                                                 
  2. ae517739 — Makefile with .PHONY: run debug targets wrapping ./gradlew bootRun --args='--spring.profiles.active=local' (and --debug-jvm for the debug target).                                                         
  3. 84fd9a48 — README "Local development" section tying it together, with the CONLUZ_JWT_SECRET_KEY precedence caveat.                                                                                                    
                                                                                                                                                                                                                           
  No .gitleaks.toml commit — empirically confirmed unnecessary (the dummy value doesn't trip gitleaks' default entropy detector; verified the detector itself works by testing a real high-entropy secret in the same      
  spot). No @Profile("production") gating found in main source, so nothing essential is silently disabled by switching to local.                                                                                           
                                                                                                                                                                                                                           
  Bonus: your local conluz-infra stack happened to already be running in this environment, so I got a full live smoke test rather than just the degraded "connection refused" check the plan anticipated — make run's      
  underlying command booted the app, connected to the real local Postgres/InfluxDB, and served GET /api-docs with a 200. (Note: port 8443 is plain HTTP here since server.ssl.enabled=false in the base config, not HTTPS  
  as CLAUDE.md's generic docs imply — that's pre-existing behavior, unrelated to this change.)