### PR TITLE
[conluz-250] Adapted versioning to avoid having to commit changes on build.gradle and derive the version from git tags

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -47,9 +47,13 @@ jobs:
 
     steps:
       # Checks out the repo at the pushed tag's commit, so the JAR built below
-      # contains the version that matches the tag.
+      # contains the version that matches the tag. fetch-depth: 0 pulls full
+      # history/tags, which build.gradle needs at build time to resolve the
+      # exact tag via `git describe --tags`.
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       # JDK 17 matches the project's toolchain (see build.gradle).
       # `cache: gradle` reuses ~/.gradle/caches across runs to speed up builds.

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -2,11 +2,14 @@
 #
 #  Trigger: The workflow runs when there is a push to the main branch.
 #
-#  Increment version: The version from build.gradle is read using grep, then split into parts (major, minor, patch). The patch version is incremented.
+#  Increment version: The latest existing version tag is read from git (sorted
+#  by semantic version), then split into parts (major, minor, patch). The
+#  patch version is incremented. build.gradle itself derives its `version` from
+#  the nearest git tag at build time (see build.gradle), so nothing is written
+#  to build.gradle or committed to main here — this workflow only creates and
+#  pushes a tag, which is unaffected by branch protection rules on `main`.
 #
-#  Commit and push changes: After updating the build.gradle file, the change is committed and pushed back to the main branch.
-#
-#  Tagging: The commit is tagged with the new version, and the tag is pushed to the remote repository.
+#  Tagging: The new version is tagged on the current HEAD, and the tag is pushed to the remote repository.
 #
 #  Image build trigger: Because tags pushed by GITHUB_TOKEN do not fire downstream
 #  push-tag events, the build-and-push-image workflow is triggered explicitly via
@@ -29,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -36,11 +41,11 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
 
-      - name: Increment version in build.gradle, commit and push version update
+      - name: Increment version and push tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(grep -oP 'version = "\K[0-9]+\.[0-9]+\.[0-9]+' build.gradle)
+          VERSION=$(git tag --list '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
           echo "Current version: $VERSION"
 
           # Increment the patch version (you can modify this to increment major/minor instead)
@@ -49,17 +54,7 @@ jobs:
           NEW_VERSION="${version_parts[0]}.${version_parts[1]}.$PATCH"
           echo "New version: $NEW_VERSION"
 
-          # Update the version in build.gradle file
-          sed -i "s/version = \"$VERSION\"/version = \"$NEW_VERSION\"/" build.gradle
-
-          # Commit and push version update
-          git config --global user.name "viktorKhan"
-          git config --global user.email "viktorKhan@users.noreply.github.com"
-          git add build.gradle
-          git commit -m "Bump version to $NEW_VERSION"
-          git push origin HEAD:main
-
-          # Tag the commit with the new version and push
+          # Tag the current commit with the new version and push
           echo "Tagging with new version: $NEW_VERSION"
           git tag "$NEW_VERSION"
           git push origin "$NEW_VERSION"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,17 @@ plugins {
 }
 
 group = 'org.lucoenergia'
-version = "1.0.133"
+
+// Version is derived from the nearest git tag reachable from HEAD (created by
+// .github/workflows/version-update.yml), not hardcoded here. This lets the
+// version-bump workflow push a tag without ever committing to `main`, so it
+// is unaffected by branch protection rules on `main`.
+def versionOutput = providers.exec {
+    commandLine 'git', 'describe', '--tags', '--abbrev=0'
+    ignoreExitValue = true
+}.standardOutput.asText.getOrElse('').trim()
+
+version = versionOutput ?: '0.0.0-dev'
 
 java {
     toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ def versionOutput = providers.exec {
     ignoreExitValue = true
 }.standardOutput.asText.getOrElse('').trim()
 
-version = versionOutput ?: '0.0.0-dev'
+version = versionOutput ?: '0.0.0'
 
 java {
     toolchain {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  - `version-update.yml` was pushing a version-bump commit directly to `main`, which now fails because `main` requires PRs (`GH006: Protected branch update failed`).                                                      
  - Docker image tags already come from the git tag (via `docker/metadata-action`), not from `build.gradle`'s version literal, so the commit-to-`main` step was unnecessary.                                               
  - `build.gradle` now derives its `version` from the nearest reachable git tag (`git describe --tags --abbrev=0`, with a `0.0.0-dev` fallback when no tag is reachable), and `version-update.yml` computes the next       
  version from the latest existing tag and only creates/pushes a tag — it no longer writes to `build.gradle` or commits/pushes to `main`.                                                                                  
  - Added `fetch-depth: 0` to the checkout steps in `version-update.yml` (needs full tag history to find the latest tag) and `build-and-push-image.yml` (needs tag history so `git describe` resolves the exact version    
  during the Gradle build).                                                                                                                                                                                                
                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                             
                                                                                                                                                                                                                           
  - [x] `./gradlew properties` locally resolves `version: 1.0.133` from the existing git tag.                                                                                                                              
  - [x] YAML syntax of both modified workflow files validated.                                                                                                                                                             
  - [ ] Merge to `main` and confirm `version-update.yml` runs, creates/pushes the next tag, and no longer attempts `git push origin HEAD:main`.                                                                            
  - [ ] Confirm `build-and-push-image.yml` fires and publishes `ghcr.io/lucoenergia/conluz:<new-version>` with the correct version baked into the JAR. 